### PR TITLE
fix(webhook): skip ref validation during deletion

### DIFF
--- a/internal/webhook/v1/vrouterbinding_webhook.go
+++ b/internal/webhook/v1/vrouterbinding_webhook.go
@@ -100,6 +100,13 @@ func (v *VRouterBindingCustomValidator) ValidateUpdate(ctx context.Context, oldO
 	}
 	vrouterbindinglog.Info("Validation for VRouterBinding upon update", "name", vrouterbinding.GetName())
 	warnings := deprecationWarnings(vrouterbinding)
+
+	// Skip ref existence validation while the object is being deleted. Referenced
+	// targets/templates may already be gone, and rejecting updates (e.g. finalizer
+	// removal) here would deadlock deletion of the binding.
+	if !vrouterbinding.GetDeletionTimestamp().IsZero() {
+		return warnings, nil
+	}
 	return warnings, validateBinding(ctx, v.Client, vrouterbinding)
 }
 

--- a/internal/webhook/v1/vrouterconfig_webhook.go
+++ b/internal/webhook/v1/vrouterconfig_webhook.go
@@ -104,6 +104,13 @@ func (v *VRouterConfigCustomValidator) ValidateUpdate(ctx context.Context, oldOb
 		return nil, fmt.Errorf("expected a VRouterConfig object for the newObj but got %T", newObj)
 	}
 	vrouterconfiglog.Info("Validation for VRouterConfig upon update", "name", vrouterconfig.GetName())
+
+	// Skip targetRef validation while the object is being deleted. The targetRef
+	// may already be gone, and rejecting updates (e.g. finalizer removal) here
+	// would deadlock deletion of the VRouterConfig and its owning binding.
+	if !vrouterconfig.GetDeletionTimestamp().IsZero() {
+		return nil, nil
+	}
 	return nil, validateVRouterConfig(ctx, v.Client, vrouterconfig)
 }
 


### PR DESCRIPTION
## Problem

When a referenced resource (e.g. a `VRouterTarget`) is deleted, the owning `VRouterConfig`/`VRouterBinding` can no longer be deleted. The controller's finalizer-removal **update** is rejected by the validating webhook because `targetRef`/`templateRefs` no longer resolve, so the object is stuck forever — and its owning binding cannot be removed either.

Observed error:
```
admission webhook "vvrouterconfig-v1.kb.io" denied the request: spec.targetRef "vyos-kubevirt" not found
```

## Fix

In `ValidateUpdate` for both `VRouterConfig` and `VRouterBinding`, skip ref existence validation when the object has a `DeletionTimestamp`. Deletion-path updates (finalizer removal, status updates) are then allowed through.

The other webhooks (`VRouterTarget`, `VRouterTemplate`, `ProxmoxCluster`) only validate their own unchanging spec and do not deadlock, so they are left unchanged.

## Test

- `go build ./...` passes
- `go test ./internal/webhook/...` passes