### PR TITLE
Fix: stop config from breaking out of the apply script

### DIFF
--- a/internal/provider/qga/script.go
+++ b/internal/provider/qga/script.go
@@ -18,8 +18,21 @@ package qga
 
 import (
 	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strings"
 	"text/template"
 )
+
+// heredocDelimiterPrefix is the stable, human-readable prefix for the config
+// heredoc delimiter. A random suffix is appended per render so the delimiter
+// cannot be predicted and embedded in the config to break out of the heredoc.
+const heredocDelimiterPrefix = "VROUTER_CONFIG_EOF_"
+
+// heredocDelimiterAttempts bounds how many times we grow the random suffix
+// while trying to find a delimiter that does not collide with the config.
+const heredocDelimiterAttempts = 8
 
 var applyScriptTmpl = template.Must(template.New("apply").Parse(`#!/bin/vbash
 if [ "$(id -g -n)" != 'vyattacfg' ] ; then
@@ -30,9 +43,9 @@ configure
 
 # --- config section ---
 {{- if .Config }}
-load /dev/stdin <<'VYOS_CONFIG_EOF'
+load /dev/stdin <<'{{ .Delimiter }}'
 {{ .Config }}
-VYOS_CONFIG_EOF
+{{ .Delimiter }}
 {{- else }}
 load /opt/vyatta/etc/config.boot.default
 {{- end }}
@@ -49,18 +62,53 @@ save
 `))
 
 type scriptData struct {
-	Config   string
-	Commands string
-	Save     bool
+	Config    string
+	Commands  string
+	Save      bool
+	Delimiter string
+}
+
+// heredocDelimiter returns a random, unpredictable delimiter that is guaranteed
+// not to appear as a standalone line inside config. The config is untrusted
+// (rendered from lower-privileged user params), so a fixed delimiter would let a
+// crafted line close the heredoc early and run the remainder as root. We derive
+// the delimiter from crypto/rand and, on the astronomically unlikely chance it
+// still collides with a config line, grow the random suffix and retry.
+func heredocDelimiter(config string) (string, error) {
+	// Index the config lines once so each candidate is an O(1) lookup.
+	lines := make(map[string]struct{})
+	for _, line := range strings.Split(config, "\n") {
+		lines[line] = struct{}{}
+	}
+
+	size := 16
+	for attempt := 0; attempt < heredocDelimiterAttempts; attempt++ {
+		buf := make([]byte, size)
+		if _, err := rand.Read(buf); err != nil {
+			return "", fmt.Errorf("generating heredoc delimiter: %w", err)
+		}
+		candidate := heredocDelimiterPrefix + hex.EncodeToString(buf)
+		if _, collides := lines[candidate]; !collides {
+			return candidate, nil
+		}
+		size *= 2
+	}
+	return "", fmt.Errorf("unable to generate collision-free heredoc delimiter after %d attempts", heredocDelimiterAttempts)
 }
 
 // RenderScript renders a vbash apply script for the given VyOS config params.
 func RenderScript(config, commands string, save bool) ([]byte, error) {
+	delimiter, err := heredocDelimiter(config)
+	if err != nil {
+		return nil, err
+	}
+
 	var buf bytes.Buffer
 	if err := applyScriptTmpl.Execute(&buf, scriptData{
-		Config:   config,
-		Commands: commands,
-		Save:     save,
+		Config:    config,
+		Commands:  commands,
+		Save:      save,
+		Delimiter: delimiter,
 	}); err != nil {
 		return nil, err
 	}

--- a/internal/provider/qga/script_test.go
+++ b/internal/provider/qga/script_test.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package qga
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// heredocStartRe matches the line that opens the config heredoc and captures
+// the quoted delimiter, e.g. `load /dev/stdin <<'DELIM'`.
+var heredocStartRe = regexp.MustCompile(`^load /dev/stdin <<'([^']+)'$`)
+
+// extractHeredocBody simulates how bash captures a quoted heredoc: it finds the
+// opening `load /dev/stdin <<'DELIM'` line, then collects every following line
+// up to (but not including) the first line that is exactly DELIM. It returns the
+// captured body, the delimiter, and the script lines that come after the closing
+// delimiter (which bash would execute as commands).
+func extractHeredocBody(t *testing.T, script string) (body, delimiter string, after []string) {
+	t.Helper()
+	lines := strings.Split(script, "\n")
+	start := -1
+	for i, line := range lines {
+		if m := heredocStartRe.FindStringSubmatch(line); m != nil {
+			start = i
+			delimiter = m[1]
+			break
+		}
+	}
+	if start == -1 {
+		t.Fatalf("no config heredoc found in script:\n%s", script)
+	}
+	for i := start + 1; i < len(lines); i++ {
+		if lines[i] == delimiter {
+			return strings.Join(lines[start+1:i], "\n"), delimiter, lines[i+1:]
+		}
+	}
+	t.Fatalf("heredoc delimiter %q never closed in script:\n%s", delimiter, script)
+	return "", "", nil
+}
+
+// TestRenderScript_MaliciousConfigCannotEscapeHeredoc verifies that config
+// content which contains the naive fixed delimiter (and other terminator-looking
+// lines) cannot break out of the heredoc and inject shell commands.
+func TestRenderScript_MaliciousConfigCannotEscapeHeredoc(t *testing.T) {
+	// Arrange: config crafted to close the old, fixed delimiter early and then
+	// run an arbitrary command as root.
+	marker := "rm -rf / # pwned by injected command"
+	malicious := strings.Join([]string{
+		"system {",
+		"    host-name router",
+		"}",
+		"VYOS_CONFIG_EOF",
+		marker,
+	}, "\n")
+
+	// Act
+	out, err := RenderScript(malicious, "", true)
+	if err != nil {
+		t.Fatalf("RenderScript returned unexpected error: %v", err)
+	}
+	script := string(out)
+
+	// Assert: the whole malicious config stays inside the heredoc body, and the
+	// injected marker never appears as an executable line after the delimiter.
+	body, delimiter, after := extractHeredocBody(t, script)
+	if body != malicious {
+		t.Fatalf("config content was altered or truncated inside heredoc.\nwant:\n%s\ngot:\n%s", malicious, body)
+	}
+	for _, line := range after {
+		if strings.Contains(line, marker) {
+			t.Fatalf("injected command escaped the heredoc and would run as root: %q", line)
+		}
+	}
+	// The chosen delimiter must not collide with any line of the config.
+	for _, line := range strings.Split(malicious, "\n") {
+		if line == delimiter {
+			t.Fatalf("delimiter %q collides with a config line, allowing breakout", delimiter)
+		}
+	}
+}
+
+// TestRenderScript_BenignConfigIntact verifies that a normal config still renders
+// correctly inside the heredoc and the script structure stays intact.
+func TestRenderScript_BenignConfigIntact(t *testing.T) {
+	config := strings.Join([]string{
+		"interfaces {",
+		"    ethernet eth0 {",
+		"        address 192.0.2.1/24",
+		"    }",
+		"}",
+	}, "\n")
+
+	out, err := RenderScript(config, "run show version", true)
+	if err != nil {
+		t.Fatalf("RenderScript returned unexpected error: %v", err)
+	}
+	script := string(out)
+
+	body, _, _ := extractHeredocBody(t, script)
+	if body != config {
+		t.Fatalf("benign config not preserved inside heredoc.\nwant:\n%s\ngot:\n%s", config, body)
+	}
+
+	for _, want := range []string{"configure", "run show version", "commit", "save"} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("expected rendered script to contain %q, script:\n%s", want, script)
+		}
+	}
+}
+
+// TestRenderScript_DelimiterIsUnpredictable verifies the delimiter is not the old
+// fixed value and differs between renders, so it cannot be guessed and embedded.
+func TestRenderScript_DelimiterIsUnpredictable(t *testing.T) {
+	config := "system {\n    host-name router\n}"
+
+	out1, err := RenderScript(config, "", false)
+	if err != nil {
+		t.Fatalf("RenderScript error: %v", err)
+	}
+	out2, err := RenderScript(config, "", false)
+	if err != nil {
+		t.Fatalf("RenderScript error: %v", err)
+	}
+
+	_, delim1, _ := extractHeredocBody(t, string(out1))
+	_, delim2, _ := extractHeredocBody(t, string(out2))
+
+	if delim1 == "VYOS_CONFIG_EOF" || delim2 == "VYOS_CONFIG_EOF" {
+		t.Fatalf("delimiter is still the predictable fixed value")
+	}
+	if delim1 == delim2 {
+		t.Fatalf("delimiter is not unpredictable between renders: %q", delim1)
+	}
+}


### PR DESCRIPTION
## The problem

When the operator applies settings to a virtual router, it builds a small shell script. The router config was placed inside a shell "heredoc" block that used a fixed end marker.

The config comes from user params that need lower access. So a user could add a line that is the same as that end marker. This would close the block early. The rest of the config would then run as shell commands as root inside the router VM. This is a command injection bug.

## What I changed

- The end marker is now a random token that is different on each render. It cannot be guessed and put in the config.
- Before use, the token is checked against every line of the config. If it would match a line, a longer random token is made and checked again.
- If a safe token still cannot be made (this is almost impossible), `RenderScript` now returns an error instead of writing an unsafe script.
- For normal config the output script works the same as before. Only the marker value changed from fixed to random.

## How I tested it

New tests in `internal/provider/qga`:
- A config that contains the old fixed marker and a fake command cannot break out of the block or run the command.
- A normal config still shows up correctly inside the block, and the script still has `configure`, `commit`, and `save`.
- The marker is not the old fixed value and is different on each render.

Checks run and passed:
- `go build ./...`
- `go test ./internal/provider/qga/...`
- `make lint` (0 issues)