### PR TITLE
fix(template): remove env, expandenv, getHostByName from templates

### DIFF
--- a/internal/template/render.go
+++ b/internal/template/render.go
@@ -27,9 +27,27 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
+// deniedFuncs lists sprig helpers that must not be reachable from templates.
+// Templates render inside the operator process, so any function that reads
+// process environment variables or performs network lookups could let a
+// VRouterTemplate author exfiltrate operator secrets (env, expandenv) or
+// trigger unwanted DNS lookups (getHostByName). SPEC §5.2 only intends safe,
+// pure helper functions (default, required, has, toYaml, range, etc.).
+var deniedFuncs = []string{"env", "expandenv", "getHostByName"}
+
+// templateFuncs returns the sprig function map with dangerous functions
+// removed, so they are unavailable to templates ("function ... not defined").
+func templateFuncs() template.FuncMap {
+	funcs := sprig.TxtFuncMap()
+	for _, name := range deniedFuncs {
+		delete(funcs, name)
+	}
+	return funcs
+}
+
 // Render executes a Go text/template with sprig functions against the given data map.
 func Render(tmplStr string, data map[string]any) (string, error) {
-	tmpl, err := template.New("").Funcs(sprig.TxtFuncMap()).Parse(tmplStr)
+	tmpl, err := template.New("").Funcs(templateFuncs()).Parse(tmplStr)
 	if err != nil {
 		return "", fmt.Errorf("parse template: %w", err)
 	}

--- a/internal/template/render_test.go
+++ b/internal/template/render_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRender_DeniesEnvFunc asserts that a template calling the sprig "env"
+// function fails to render, since it is not registered in the FuncMap.
+// This prevents a VRouterTemplate author from reading the operator
+// process's environment variables (which may hold injected secrets).
+func TestRender_DeniesEnvFunc(t *testing.T) {
+	t.Setenv("HOME", "/should/not/leak")
+
+	out, err := Render(`{{ env "HOME" }}`, map[string]any{})
+	if err == nil {
+		t.Fatalf("expected error for disabled env func, got output %q", out)
+	}
+	if !strings.Contains(err.Error(), "function \"env\" not defined") {
+		t.Fatalf("expected 'function \"env\" not defined' error, got: %v", err)
+	}
+}
+
+// TestRender_DeniesExpandenvFunc asserts that a template calling the sprig
+// "expandenv" function fails to render for the same reason as env above.
+func TestRender_DeniesExpandenvFunc(t *testing.T) {
+	t.Setenv("HOME", "/should/not/leak")
+
+	out, err := Render(`{{ expandenv "$HOME" }}`, map[string]any{})
+	if err == nil {
+		t.Fatalf("expected error for disabled expandenv func, got output %q", out)
+	}
+	if !strings.Contains(err.Error(), "function \"expandenv\" not defined") {
+		t.Fatalf("expected 'function \"expandenv\" not defined' error, got: %v", err)
+	}
+}
+
+// TestRender_DeniesGetHostByNameFunc asserts that a template calling the
+// sprig "getHostByName" function fails to render, since it lets a template
+// author trigger DNS lookups from the operator process.
+func TestRender_DeniesGetHostByNameFunc(t *testing.T) {
+	out, err := Render(`{{ getHostByName "localhost" }}`, map[string]any{})
+	if err == nil {
+		t.Fatalf("expected error for disabled getHostByName func, got output %q", out)
+	}
+	if !strings.Contains(err.Error(), "function \"getHostByName\" not defined") {
+		t.Fatalf("expected 'function \"getHostByName\" not defined' error, got: %v", err)
+	}
+}
+
+// TestRender_BenignTemplateStillWorks proves that removing the dangerous
+// functions does not break normal template usage: field interpolation and
+// the sprig "default" helper (used by SPEC §5.2) both still work.
+func TestRender_BenignTemplateStillWorks(t *testing.T) {
+	data := map[string]any{
+		"Name": "router-1",
+	}
+
+	out, err := Render(`hostname {{ .Name }}; mtu {{ .MTU | default "1500" }};`, data)
+	if err != nil {
+		t.Fatalf("unexpected error rendering benign template: %v", err)
+	}
+
+	want := `hostname router-1; mtu 1500;`
+	if out != want {
+		t.Fatalf("unexpected render output: got %q, want %q", out, want)
+	}
+}


### PR DESCRIPTION
## What was the problem

Templates are rendered inside the operator process. The template engine
used the full sprig function map, which includes `env`, `expandenv`, and
`getHostByName`.

This means a template author could write `{{ env "SOME_SECRET" }}` or
`{{ expandenv "$X" }}` in a template and read the operator pod's
environment variables directly into the rendered config or commands.
Some of those environment variables may hold injected secrets or tokens.
`getHostByName` also let a template trigger DNS lookups from inside the
operator process.

## What changed

- `internal/template/render.go`: build the template function map from
  sprig, then remove `env`, `expandenv`, and `getHostByName` before
  parsing. These functions are now undefined inside templates and calling
  them fails to render. All other sprig helpers (`default`, `required`,
  `has`, `toYaml`, `range`, etc.) still work the same as before.

## How I tested it

Added `internal/template/render_test.go` with four tests:
- `TestRender_DeniesEnvFunc`: a template using `{{ env "HOME" }}` now
  fails to render with a "function not defined" error.
- `TestRender_DeniesExpandenvFunc`: same check for `expandenv`.
- `TestRender_DeniesGetHostByNameFunc`: same check for `getHostByName`.
- `TestRender_BenignTemplateStillWorks`: a normal template using field
  interpolation and the `default` helper still renders correctly.

Also ran:
- `go build ./...` — passes
- `go test ./internal/template/...` — all 4 tests pass
- `make lint` — 0 issues