### PR TITLE
fix(webhook): reject cross-namespace references

### DIFF
--- a/internal/webhook/v1/crossns_test.go
+++ b/internal/webhook/v1/crossns_test.go
@@ -1,0 +1,202 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	vrouterv1 "github.com/tjjh89017/vrouter-operator/api/v1"
+)
+
+// newTestClient builds an in-process fake client (no envtest binaries required)
+// seeded with the given objects, for exercising the ref-existence lookups that
+// validateBinding / validateVRouterConfig perform.
+func newTestClient(t *testing.T, objs ...client.Object) client.Client {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := vrouterv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to register scheme: %v", err)
+	}
+	builder := fake.NewClientBuilder().WithScheme(scheme)
+	if len(objs) > 0 {
+		builder = builder.WithObjects(objs...)
+	}
+	return builder.Build()
+}
+
+// testNamespace is the namespace of the "referencing" object in every test
+// case below; refs pointing anywhere else are cross-namespace.
+const testNamespace = "tenant-a"
+
+// metaObj is a small helper to build ObjectMeta for test fixtures in testNamespace.
+func metaObj(name string) metav1.ObjectMeta {
+	return metav1.ObjectMeta{Namespace: testNamespace, Name: name}
+}
+
+func TestValidateBinding_CrossNamespaceRefs_Rejected(t *testing.T) {
+	tests := []struct {
+		name    string
+		binding *vrouterv1.VRouterBinding
+		wantErr string
+	}{
+		{
+			name: "cross-namespace targetRefs entry is rejected",
+			binding: &vrouterv1.VRouterBinding{
+				ObjectMeta: metaObj("b1"),
+				Spec: vrouterv1.VRouterBindingSpec{
+					TemplateRefs: []vrouterv1.NameRef{{Name: "tmpl1"}},
+					TargetRefs:   []vrouterv1.NameRef{{Name: "r1", Namespace: "infra"}},
+				},
+			},
+			wantErr: "cross-namespace reference not allowed: spec.targetRefs[0]",
+		},
+		{
+			name: "cross-namespace templateRefs entry is rejected",
+			binding: &vrouterv1.VRouterBinding{
+				ObjectMeta: metaObj("b2"),
+				Spec: vrouterv1.VRouterBindingSpec{
+					TemplateRefs: []vrouterv1.NameRef{{Name: "tmpl1", Namespace: "infra"}},
+					TargetRefs:   []vrouterv1.NameRef{{Name: "r1"}},
+				},
+			},
+			wantErr: "cross-namespace reference not allowed: spec.templateRefs[0]",
+		},
+		{
+			name: "cross-namespace deprecated templateRef is rejected",
+			binding: &vrouterv1.VRouterBinding{
+				ObjectMeta: metaObj("b3"),
+				Spec: vrouterv1.VRouterBindingSpec{
+					TemplateRef: &vrouterv1.NameRef{Name: "tmpl1", Namespace: "infra"}, //nolint:staticcheck // backward compat
+					TargetRefs:  []vrouterv1.NameRef{{Name: "r1"}},
+				},
+			},
+			wantErr: "cross-namespace reference not allowed: spec.templateRef",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Seed the same-namespace refs used by each case's non-offending
+			// fields, so the failure only comes from the cross-namespace ref
+			// under test (not an earlier "not found" from an unrelated field).
+			tmpl1 := &vrouterv1.VRouterTemplate{ObjectMeta: metaObj("tmpl1")}
+			r1 := &vrouterv1.VRouterTarget{ObjectMeta: metaObj("r1")}
+			cl := newTestClient(t, tmpl1, r1)
+			err := validateBinding(context.Background(), cl, tt.binding)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %q, want substring %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateBinding_SameNamespaceRefs_Accepted(t *testing.T) {
+	binding := &vrouterv1.VRouterBinding{
+		ObjectMeta: metaObj("b1"),
+		Spec: vrouterv1.VRouterBindingSpec{
+			TemplateRefs: []vrouterv1.NameRef{{Name: "tmpl1"}},
+			// Explicit same-namespace value and empty (defaulted) namespace both count as same-namespace.
+			TargetRefs: []vrouterv1.NameRef{{Name: "r1", Namespace: testNamespace}, {Name: "r2"}},
+		},
+	}
+
+	tmpl := &vrouterv1.VRouterTemplate{ObjectMeta: metaObj("tmpl1")}
+	r1 := &vrouterv1.VRouterTarget{ObjectMeta: metaObj("r1")}
+	r2 := &vrouterv1.VRouterTarget{ObjectMeta: metaObj("r2")}
+	cl := newTestClient(t, tmpl, r1, r2)
+
+	if err := validateBinding(context.Background(), cl, binding); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestValidateVRouterConfig_CrossNamespaceTargetRef_Rejected(t *testing.T) {
+	cfg := &vrouterv1.VRouterConfig{
+		ObjectMeta: metaObj("c1"),
+		Spec: vrouterv1.VRouterConfigSpec{
+			TargetRef: vrouterv1.NameRef{Name: "r1", Namespace: "infra"},
+		},
+	}
+	// No target object seeded: the cross-namespace rejection must happen before
+	// the existence lookup.
+	cl := newTestClient(t)
+
+	err := validateVRouterConfig(context.Background(), cl, cfg)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "cross-namespace reference not allowed: spec.targetRef") {
+		t.Fatalf("error = %q, want cross-namespace rejection", err.Error())
+	}
+}
+
+func TestValidateVRouterConfig_SameNamespaceTargetRef_Accepted(t *testing.T) {
+	cfg := &vrouterv1.VRouterConfig{
+		ObjectMeta: metaObj("c1"),
+		Spec: vrouterv1.VRouterConfigSpec{
+			TargetRef: vrouterv1.NameRef{Name: "r1"},
+		},
+	}
+	target := &vrouterv1.VRouterTarget{ObjectMeta: metaObj("r1")}
+	cl := newTestClient(t, target)
+
+	if err := validateVRouterConfig(context.Background(), cl, cfg); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestValidateProviderConfig_ProxmoxClusterRef_CrossNamespace_Rejected(t *testing.T) {
+	provider := vrouterv1.ProviderConfig{
+		Type: vrouterv1.ProviderProxmox,
+		Proxmox: &vrouterv1.ProxmoxConfig{
+			VMID:       100,
+			ClusterRef: vrouterv1.NameRef{Name: "pve", Namespace: "infra"},
+		},
+	}
+
+	err := validateProviderConfig(provider, testNamespace)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "cross-namespace reference not allowed: provider.proxmox.clusterRef") {
+		t.Fatalf("error = %q, want cross-namespace rejection", err.Error())
+	}
+}
+
+func TestValidateProviderConfig_ProxmoxClusterRef_SameNamespace_Accepted(t *testing.T) {
+	provider := vrouterv1.ProviderConfig{
+		Type: vrouterv1.ProviderProxmox,
+		Proxmox: &vrouterv1.ProxmoxConfig{
+			VMID:       100,
+			ClusterRef: vrouterv1.NameRef{Name: "pve"},
+		},
+	}
+
+	if err := validateProviderConfig(provider, testNamespace); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}

--- a/internal/webhook/v1/validation.go
+++ b/internal/webhook/v1/validation.go
@@ -24,7 +24,9 @@ import (
 
 // validateProviderConfig checks that the provider-specific sub-config is present
 // for the declared provider type. Field-level validation is handled by kubebuilder markers.
-func validateProviderConfig(provider vrouterv1.ProviderConfig) error {
+// namespace is the namespace of the object that owns this provider config (e.g. the
+// VRouterTarget), used to reject cross-namespace references.
+func validateProviderConfig(provider vrouterv1.ProviderConfig, namespace string) error {
 	switch provider.Type {
 	case vrouterv1.ProviderKubeVirt, "":
 		if provider.KubeVirt == nil {
@@ -36,6 +38,9 @@ func validateProviderConfig(provider vrouterv1.ProviderConfig) error {
 		}
 		if provider.Proxmox.ClusterRef.Name == "" {
 			return fmt.Errorf("provider.proxmox.clusterRef.name must be set")
+		}
+		if ns := vrouterv1.ResolveNamespace(provider.Proxmox.ClusterRef, namespace); ns != namespace {
+			return fmt.Errorf("cross-namespace reference not allowed: provider.proxmox.clusterRef may only reference the same namespace")
 		}
 	case vrouterv1.ProviderVRouterDaemon:
 		if provider.Daemon == nil {

--- a/internal/webhook/v1/vrouterbinding_webhook.go
+++ b/internal/webhook/v1/vrouterbinding_webhook.go
@@ -144,6 +144,9 @@ func validateBinding(ctx context.Context, cl client.Client, binding *vrouterv1.V
 		var tmpl vrouterv1.VRouterTemplate
 		ref := *binding.Spec.TemplateRef //nolint:staticcheck // backward compat
 		ns := vrouterv1.ResolveNamespace(ref, binding.Namespace)
+		if ns != binding.Namespace {
+			return fmt.Errorf("cross-namespace reference not allowed: spec.templateRef may only reference the same namespace")
+		}
 		if err := cl.Get(ctx, types.NamespacedName{Namespace: ns, Name: ref.Name}, &tmpl); err != nil {
 			if apierrors.IsNotFound(err) {
 				return fmt.Errorf("spec.templateRef %q (namespace %q) not found", ref.Name, ns)
@@ -156,6 +159,9 @@ func validateBinding(ctx context.Context, cl client.Client, binding *vrouterv1.V
 	for i, ref := range binding.Spec.TemplateRefs {
 		var tmpl vrouterv1.VRouterTemplate
 		ns := vrouterv1.ResolveNamespace(ref, binding.Namespace)
+		if ns != binding.Namespace {
+			return fmt.Errorf("cross-namespace reference not allowed: spec.templateRefs[%d] may only reference the same namespace", i)
+		}
 		if err := cl.Get(ctx, types.NamespacedName{Namespace: ns, Name: ref.Name}, &tmpl); err != nil {
 			if apierrors.IsNotFound(err) {
 				return fmt.Errorf("spec.templateRefs[%d] %q (namespace %q) not found", i, ref.Name, ns)
@@ -165,9 +171,12 @@ func validateBinding(ctx context.Context, cl client.Client, binding *vrouterv1.V
 	}
 
 	// Verify each targetRef exists.
-	for _, ref := range binding.Spec.TargetRefs {
+	for i, ref := range binding.Spec.TargetRefs {
 		var target vrouterv1.VRouterTarget
 		ns := vrouterv1.ResolveNamespace(ref, binding.Namespace)
+		if ns != binding.Namespace {
+			return fmt.Errorf("cross-namespace reference not allowed: spec.targetRefs[%d] may only reference the same namespace", i)
+		}
 		if err := cl.Get(ctx, types.NamespacedName{Namespace: ns, Name: ref.Name}, &target); err != nil {
 			if apierrors.IsNotFound(err) {
 				return fmt.Errorf("spec.targetRefs %q (namespace %q) not found", ref.Name, ns)

--- a/internal/webhook/v1/vrouterconfig_webhook.go
+++ b/internal/webhook/v1/vrouterconfig_webhook.go
@@ -115,6 +115,10 @@ func (v *VRouterConfigCustomValidator) ValidateUpdate(ctx context.Context, oldOb
 }
 
 func validateVRouterConfig(ctx context.Context, cl client.Client, cfg *vrouterv1.VRouterConfig) error {
+	ns := vrouterv1.ResolveNamespace(cfg.Spec.TargetRef, cfg.Namespace)
+	if ns != cfg.Namespace {
+		return fmt.Errorf("cross-namespace reference not allowed: spec.targetRef may only reference the same namespace")
+	}
 	var target vrouterv1.VRouterTarget
 	if err := cl.Get(ctx, types.NamespacedName{Namespace: cfg.Namespace, Name: cfg.Spec.TargetRef.Name}, &target); err != nil {
 		if apierrors.IsNotFound(err) {

--- a/internal/webhook/v1/vroutertarget_webhook.go
+++ b/internal/webhook/v1/vroutertarget_webhook.go
@@ -92,7 +92,7 @@ func (v *VRouterTargetCustomValidator) ValidateCreate(_ context.Context, obj run
 	}
 	vroutertargetlog.Info("Validation for VRouterTarget upon creation", "name", vroutertarget.GetName())
 
-	return nil, validateProviderConfig(vroutertarget.Spec.Provider)
+	return nil, validateProviderConfig(vroutertarget.Spec.Provider, vroutertarget.Namespace)
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type VRouterTarget.
@@ -103,7 +103,14 @@ func (v *VRouterTargetCustomValidator) ValidateUpdate(_ context.Context, oldObj,
 	}
 	vroutertargetlog.Info("Validation for VRouterTarget upon update", "name", vroutertarget.GetName())
 
-	return nil, validateProviderConfig(vroutertarget.Spec.Provider)
+	// Skip validation while the object is being deleted, consistent with the
+	// deletion-path skip used by the binding and config webhooks: a resource that
+	// was valid when created (e.g. before this check existed) must not be blocked
+	// from having its finalizer removed.
+	if !vroutertarget.GetDeletionTimestamp().IsZero() {
+		return nil, nil
+	}
+	return nil, validateProviderConfig(vroutertarget.Spec.Provider, vroutertarget.Namespace)
 }
 
 // ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type VRouterTarget.


### PR DESCRIPTION
## What was the risk

A user who could only create objects in one namespace (for example `tenant-a`) could still point a `VRouterBinding`, `VRouterConfig`, or `VRouterTarget` at a resource in a different namespace, by setting the `namespace` field on a reference (`templateRef`, `targetRef`, or a Proxmox `clusterRef`).

The operator uses its own privileged service account to read the referenced object and run rendered commands on the virtual router. So a user in `tenant-a` could reference a target or Proxmox cluster in `infra` and use `infra`'s credentials to run commands as root on `infra`'s virtual router. This is a confused-deputy problem: the operator acted with more trust than the requesting user had.

## What changed

The validating webhooks now reject any reference whose namespace is different from the namespace of the object doing the referencing:

- `VRouterBinding`: `spec.templateRef`, `spec.templateRefs[]`, `spec.targetRefs[]`
- `VRouterConfig`: `spec.targetRef`
- `VRouterTarget`: `spec.provider.proxmox.clusterRef`

A reference with no namespace set (or the same namespace) still works as before. This check is skipped while an object is being deleted, the same way the existing "does this reference still exist" check is skipped, so removing a finalizer during deletion is never blocked.

No existing check was removed or weakened; this only adds the new same-namespace rule.

## How this was tested

- `go build ./...` passes.
- `go vet ./...` passes.
- `make lint` passes (0 issues).
- New unit tests in `internal/webhook/v1/crossns_test.go`, using an in-memory fake Kubernetes client (no envtest binaries needed):
  - `TestValidateBinding_CrossNamespaceRefs_Rejected` (targetRefs, templateRefs, and the deprecated templateRef, each rejected)
  - `TestValidateBinding_SameNamespaceRefs_Accepted`
  - `TestValidateVRouterConfig_CrossNamespaceTargetRef_Rejected`
  - `TestValidateVRouterConfig_SameNamespaceTargetRef_Accepted`
  - `TestValidateProviderConfig_ProxmoxClusterRef_CrossNamespace_Rejected`
  - `TestValidateProviderConfig_ProxmoxClusterRef_SameNamespace_Accepted`
- `go test ./internal/webhook/v1/... ./api/...` passes.

## Test plan

- [x] Cross-namespace reference is rejected on create/update for binding, config, and target
- [x] Same-namespace (or empty namespace) reference still works
- [x] Deletion of an object with a stale/cross-namespace reference is not blocked
- [x] `make lint` is clean