### PR TITLE
fix(provider): default kubevirt namespace to the target namespace

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -78,6 +78,14 @@ func New(ctx context.Context, target *vrouterv1.VRouterTarget, cl client.Client,
 		if cfg.KubeVirt == nil {
 			return nil, fmt.Errorf("provider.kubevirt must be set when type is kubevirt")
 		}
-		return kubevirt.New(cl, restCfg, cfg.KubeVirt.Name, cfg.KubeVirt.Namespace)
+		// provider.kubevirt.namespace is optional and defaults to the
+		// VRouterTarget's own namespace (see docs/SPEC.md §3.2). Without this
+		// fallback the provider would look up the VMI in the empty
+		// namespace, get NotFound, and silently treat the VM as stopped.
+		ns := cfg.KubeVirt.Namespace
+		if ns == "" {
+			ns = target.Namespace
+		}
+		return kubevirt.New(cl, restCfg, cfg.KubeVirt.Name, ns)
 	}
 }

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	vrouterv1 "github.com/tjjh89017/vrouter-operator/api/v1"
+)
+
+func newTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := vrouterv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add vrouterv1 to scheme: %v", err)
+	}
+	if err := kubevirtv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add kubevirtv1 to scheme: %v", err)
+	}
+	return scheme
+}
+
+func runningVMI(name, namespace string) *kubevirtv1.VirtualMachineInstance {
+	return &kubevirtv1.VirtualMachineInstance{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Status:     kubevirtv1.VirtualMachineInstanceStatus{Phase: kubevirtv1.Running},
+	}
+}
+
+// should default the KubeVirt namespace to the VRouterTarget's own namespace
+// when provider.kubevirt.namespace is omitted, so the provider looks up the
+// VMI in the correct namespace instead of the empty string.
+func TestNew_KubeVirtNamespaceDefaultsToTargetNamespace(t *testing.T) {
+	ctx := context.Background()
+	scheme := newTestScheme(t)
+
+	// The VMI lives in "foo", the same namespace as the VRouterTarget.
+	vmi := runningVMI("vm1", "foo")
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(vmi).Build()
+
+	target := &vrouterv1.VRouterTarget{
+		ObjectMeta: metav1.ObjectMeta{Name: "target1", Namespace: "foo"},
+		Spec: vrouterv1.VRouterTargetSpec{
+			Provider: vrouterv1.ProviderConfig{
+				Type:     vrouterv1.ProviderType("kubevirt"),
+				KubeVirt: &vrouterv1.KubeVirtConfig{Name: "vm1"}, // Namespace intentionally omitted
+			},
+		},
+	}
+
+	p, err := New(ctx, target, cl, &rest.Config{})
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+
+	running, err := p.IsVMRunning(ctx)
+	if err != nil {
+		t.Fatalf("IsVMRunning() returned error: %v", err)
+	}
+	if !running {
+		t.Fatalf("IsVMRunning() = false, want true (namespace should default to target namespace %q, not empty string)", target.Namespace)
+	}
+}
+
+// should respect an explicitly set provider.kubevirt.namespace instead of
+// overriding it with the VRouterTarget's own namespace.
+func TestNew_KubeVirtExplicitNamespaceIsRespected(t *testing.T) {
+	ctx := context.Background()
+	scheme := newTestScheme(t)
+
+	// A VMI named "vm1" exists in both namespaces so a namespace mix-up would
+	// still return a (wrong) result instead of an obvious NotFound: the one in
+	// "foo" (the target's own namespace) is stopped, while the one in the
+	// explicitly configured "bar" namespace is running.
+	stoppedVMI := &kubevirtv1.VirtualMachineInstance{
+		ObjectMeta: metav1.ObjectMeta{Name: "vm1", Namespace: "foo"},
+		Status:     kubevirtv1.VirtualMachineInstanceStatus{Phase: kubevirtv1.Succeeded},
+	}
+	runningInBar := runningVMI("vm1", "bar")
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(stoppedVMI, runningInBar).Build()
+
+	target := &vrouterv1.VRouterTarget{
+		ObjectMeta: metav1.ObjectMeta{Name: "target1", Namespace: "foo"},
+		Spec: vrouterv1.VRouterTargetSpec{
+			Provider: vrouterv1.ProviderConfig{
+				Type:     vrouterv1.ProviderType("kubevirt"),
+				KubeVirt: &vrouterv1.KubeVirtConfig{Name: "vm1", Namespace: "bar"},
+			},
+		},
+	}
+
+	p, err := New(ctx, target, cl, &rest.Config{})
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+
+	running, err := p.IsVMRunning(ctx)
+	if err != nil {
+		t.Fatalf("IsVMRunning() returned error: %v", err)
+	}
+	if !running {
+		t.Fatalf("IsVMRunning() = false, want true (explicit namespace %q should be used, not target namespace %q)", "bar", target.Namespace)
+	}
+}


### PR DESCRIPTION
## Problem

The `kubevirt.namespace` field is optional. When it is left empty, it
should default to the same namespace as the VRouterTarget. But the
provider factory (`internal/provider/provider.go`) passed the empty
string straight to the KubeVirt provider instead of filling in the
default.

This made the operator look up the virtual machine in the wrong place
(namespace `""`), which always returns "not found". The operator then
decided the VM was stopped and skipped applying the config. This
happened silently: no error, no condition, no requeue. The config
just stayed in `Pending` forever with no clue why.

## Fix

In `provider.New`, when `cfg.KubeVirt.Namespace` is empty, use
`target.Namespace` instead. This matches the same fallback already
used by the two VMI watch-mapping functions
(`vmiToVRouterConfigs`, `vmiToVRouterTargets`), so the behavior is now
consistent across the codebase.

An explicitly set `kubevirt.namespace` is not touched, it still wins.

## How tested

Added `internal/provider/provider_test.go` with two tests using a fake
client:

- `TestNew_KubeVirtNamespaceDefaultsToTargetNamespace`: namespace is
  omitted, VMI lives in the target's own namespace. Before the fix,
  `IsVMRunning` returned `false` (VMI not found in `""`). After the
  fix, it correctly returns `true`.
- `TestNew_KubeVirtExplicitNamespaceIsRespected`: namespace is set
  explicitly to a different namespace than the target. A VMI with the
  same name also exists (but stopped) in the target's own namespace,
  to prove the explicit namespace is used and not silently
  overridden.

Also ran:
- `go build ./...` — passes
- `go vet ./...` — passes
- `go test ./internal/provider/...` — passes
- `go test ./internal/controller/...` — passes (no regressions)
- `make lint` — 0 issues