### PR TITLE
fix(webhook): validate proxmoxcluster spec

### DIFF
--- a/internal/webhook/v1/proxmoxcluster_webhook.go
+++ b/internal/webhook/v1/proxmoxcluster_webhook.go
@@ -70,7 +70,6 @@ func (d *ProxmoxClusterCustomDefaulter) Default(_ context.Context, obj runtime.O
 	return nil
 }
 
-// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 // NOTE: The 'path' attribute must follow a specific pattern and should not be modified directly here.
 // Modifying the path for an invalid path can cause API server errors; failing to locate the webhook.
 // +kubebuilder:webhook:path=/validate-vrouter-kojuro-date-v1-proxmoxcluster,mutating=false,failurePolicy=fail,sideEffects=None,groups=vrouter.kojuro.date,resources=proxmoxclusters,verbs=create;update,versions=v1,name=vproxmoxcluster-v1.kb.io,admissionReviewVersions=v1
@@ -81,7 +80,6 @@ func (d *ProxmoxClusterCustomDefaulter) Default(_ context.Context, obj runtime.O
 // NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
 // as this struct is used only for temporary operations and does not need to be deeply copied.
 type ProxmoxClusterCustomValidator struct {
-	// TODO(user): Add more fields as needed for validation
 }
 
 var _ webhook.CustomValidator = &ProxmoxClusterCustomValidator{}
@@ -94,22 +92,51 @@ func (v *ProxmoxClusterCustomValidator) ValidateCreate(_ context.Context, obj ru
 	}
 	proxmoxclusterlog.Info("Validation for ProxmoxCluster upon creation", "name", proxmoxcluster.GetName())
 
-	// TODO(user): fill in your validation logic upon object creation.
-
-	return nil, nil
+	return nil, validateProxmoxCluster(proxmoxcluster)
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type ProxmoxCluster.
-func (v *ProxmoxClusterCustomValidator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+func (v *ProxmoxClusterCustomValidator) ValidateUpdate(_ context.Context, _, newObj runtime.Object) (admission.Warnings, error) {
 	proxmoxcluster, ok := newObj.(*vrouterv1.ProxmoxCluster)
 	if !ok {
 		return nil, fmt.Errorf("expected a ProxmoxCluster object for the newObj but got %T", newObj)
 	}
 	proxmoxclusterlog.Info("Validation for ProxmoxCluster upon update", "name", proxmoxcluster.GetName())
 
-	// TODO(user): fill in your validation logic upon object update.
+	// Skip validation while the object is being deleted. The spec may already be
+	// stale by then, and rejecting the update (e.g. finalizer removal) here would
+	// deadlock deletion of the ProxmoxCluster.
+	if !proxmoxcluster.GetDeletionTimestamp().IsZero() {
+		return nil, nil
+	}
 
-	return nil, nil
+	return nil, validateProxmoxCluster(proxmoxcluster)
+}
+
+// validateProxmoxCluster checks that a ProxmoxCluster's spec is usable by the
+// controller before it is admitted. An empty endpoints list, a non-positive
+// syncInterval, or an empty credentialsRef.name would otherwise only surface
+// deep in reconcile (or, for syncInterval, as a hot-poll loop against the
+// Proxmox API), so we reject them here instead.
+func validateProxmoxCluster(cluster *vrouterv1.ProxmoxCluster) error {
+	if len(cluster.Spec.Endpoints) == 0 {
+		return fmt.Errorf("spec.endpoints must not be empty")
+	}
+	for i, endpoint := range cluster.Spec.Endpoints {
+		if endpoint == "" {
+			return fmt.Errorf("spec.endpoints[%d] must not be empty", i)
+		}
+	}
+
+	if cluster.Spec.SyncInterval.Duration <= 0 {
+		return fmt.Errorf("spec.syncInterval must be greater than zero")
+	}
+
+	if cluster.Spec.CredentialsRef.Name == "" {
+		return fmt.Errorf("spec.credentialsRef.name must be set")
+	}
+
+	return nil
 }
 
 // ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type ProxmoxCluster.

--- a/internal/webhook/v1/proxmoxcluster_webhook_test.go
+++ b/internal/webhook/v1/proxmoxcluster_webhook_test.go
@@ -17,11 +17,14 @@ limitations under the License.
 package v1
 
 import (
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	vrouterv1 "github.com/tjjh89017/vrouter-operator/api/v1"
-	// TODO (user): Add any additional imports if needed
 )
 
 var _ = Describe("ProxmoxCluster Webhook", func() {
@@ -32,56 +35,112 @@ var _ = Describe("ProxmoxCluster Webhook", func() {
 		defaulter ProxmoxClusterCustomDefaulter
 	)
 
+	// validSpec returns a ProxmoxClusterSpec that satisfies every field the
+	// validating webhook checks.
+	validSpec := func() vrouterv1.ProxmoxClusterSpec {
+		return vrouterv1.ProxmoxClusterSpec{
+			Endpoints: []string{"https://pve.example.com:8006"},
+			CredentialsRef: vrouterv1.SecretReference{
+				Name: "pve-credentials",
+			},
+			SyncInterval: metav1.Duration{Duration: 60 * time.Second},
+		}
+	}
+
 	BeforeEach(func() {
-		obj = &vrouterv1.ProxmoxCluster{}
-		oldObj = &vrouterv1.ProxmoxCluster{}
+		obj = &vrouterv1.ProxmoxCluster{Spec: validSpec()}
+		oldObj = &vrouterv1.ProxmoxCluster{Spec: validSpec()}
 		validator = ProxmoxClusterCustomValidator{}
 		Expect(validator).NotTo(BeNil(), "Expected validator to be initialized")
 		defaulter = ProxmoxClusterCustomDefaulter{}
 		Expect(defaulter).NotTo(BeNil(), "Expected defaulter to be initialized")
 		Expect(oldObj).NotTo(BeNil(), "Expected oldObj to be initialized")
 		Expect(obj).NotTo(BeNil(), "Expected obj to be initialized")
-		// TODO (user): Add any setup logic common to all tests
-	})
-
-	AfterEach(func() {
-		// TODO (user): Add any teardown logic common to all tests
-	})
-
-	Context("When creating ProxmoxCluster under Defaulting Webhook", func() {
-		// TODO (user): Add logic for defaulting webhooks
-		// Example:
-		// It("Should apply defaults when a required field is empty", func() {
-		//     By("simulating a scenario where defaults should be applied")
-		//     obj.SomeFieldWithDefault = ""
-		//     By("calling the Default method to apply defaults")
-		//     defaulter.Default(ctx, obj)
-		//     By("checking that the default values are set")
-		//     Expect(obj.SomeFieldWithDefault).To(Equal("default_value"))
-		// })
 	})
 
 	Context("When creating or updating ProxmoxCluster under Validating Webhook", func() {
-		// TODO (user): Add logic for validating webhooks
-		// Example:
-		// It("Should deny creation if a required field is missing", func() {
-		//     By("simulating an invalid creation scenario")
-		//     obj.SomeRequiredField = ""
-		//     Expect(validator.ValidateCreate(ctx, obj)).Error().To(HaveOccurred())
-		// })
-		//
-		// It("Should admit creation if all required fields are present", func() {
-		//     By("simulating an invalid creation scenario")
-		//     obj.SomeRequiredField = "valid_value"
-		//     Expect(validator.ValidateCreate(ctx, obj)).To(BeNil())
-		// })
-		//
-		// It("Should validate updates correctly", func() {
-		//     By("simulating a valid update scenario")
-		//     oldObj.SomeRequiredField = "updated_value"
-		//     obj.SomeRequiredField = "updated_value"
-		//     Expect(validator.ValidateUpdate(ctx, oldObj, obj)).To(BeNil())
-		// })
-	})
+		It("Should admit a fully valid spec on create", func() {
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).NotTo(HaveOccurred())
+		})
 
+		It("Should admit a fully valid spec on update", func() {
+			_, err := validator.ValidateUpdate(ctx, oldObj, obj)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Should deny creation when spec.endpoints is empty", func() {
+			obj.Spec.Endpoints = []string{}
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("spec.endpoints"))
+		})
+
+		It("Should deny update when spec.endpoints is empty", func() {
+			obj.Spec.Endpoints = []string{}
+			_, err := validator.ValidateUpdate(ctx, oldObj, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("spec.endpoints"))
+		})
+
+		It("Should deny creation when an endpoint entry is blank", func() {
+			obj.Spec.Endpoints = []string{""}
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("spec.endpoints[0]"))
+		})
+
+		It("Should deny creation when spec.syncInterval is zero", func() {
+			obj.Spec.SyncInterval = metav1.Duration{}
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("spec.syncInterval"))
+		})
+
+		It("Should deny creation when spec.syncInterval is negative", func() {
+			obj.Spec.SyncInterval = metav1.Duration{Duration: -60 * time.Second}
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("spec.syncInterval"))
+		})
+
+		It("Should deny update when spec.syncInterval is negative", func() {
+			obj.Spec.SyncInterval = metav1.Duration{Duration: -60 * time.Second}
+			_, err := validator.ValidateUpdate(ctx, oldObj, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("spec.syncInterval"))
+		})
+
+		It("Should admit a positive spec.syncInterval", func() {
+			obj.Spec.SyncInterval = metav1.Duration{Duration: 30 * time.Second}
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Should deny creation when spec.credentialsRef.name is empty", func() {
+			obj.Spec.CredentialsRef.Name = ""
+			_, err := validator.ValidateCreate(ctx, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("spec.credentialsRef.name"))
+		})
+
+		It("Should deny update when spec.credentialsRef.name is empty", func() {
+			obj.Spec.CredentialsRef.Name = ""
+			_, err := validator.ValidateUpdate(ctx, oldObj, obj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("spec.credentialsRef.name"))
+		})
+
+		It("Should skip validation on update when the object is being deleted", func() {
+			now := metav1.Now()
+			obj.DeletionTimestamp = &now
+			obj.Finalizers = []string{"example.com/finalizer"}
+			obj.Spec.Endpoints = []string{}
+			obj.Spec.SyncInterval = metav1.Duration{Duration: -60 * time.Second}
+			obj.Spec.CredentialsRef.Name = ""
+
+			_, err := validator.ValidateUpdate(ctx, oldObj, obj)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
 })


### PR DESCRIPTION
## What was wrong

The ProxmoxCluster validating webhook was empty (a TODO scaffold). This meant Kubernetes would accept bad specs that only caused problems later:

- `endpoints: []` (an empty list) — the controller has nothing to sync against and can never work.
- `syncInterval` set to `0` or a negative value, like `-60s` — the controller only checks for `== 0`, so a negative value makes it skip its own delay check and poll the Proxmox API on every reconcile (a hot loop).
- `credentialsRef.name: ""` (empty) — this only fails much later, when the controller tries to read the secret.

## The fix

`internal/webhook/v1/proxmoxcluster_webhook.go` now checks these rules on both create and update:
- `spec.endpoints` must have at least one entry, and no entry may be blank.
- `spec.syncInterval` must be greater than zero.
- `spec.credentialsRef.name` must not be empty.

Validation is skipped while the object is being deleted, so removing the finalizer during deletion is never blocked (this matches the pattern already used by the other webhooks in this repo).

This is a webhook-only change. No CRD schema markers were added on purpose, to avoid a conflict with another open PR (#16) that already touches the ProxmoxCluster CRD YAML.

## How this was tested

Added real Ginkgo tests in `internal/webhook/v1/proxmoxcluster_webhook_test.go` (the file was also an empty scaffold before), covering:
- empty `endpoints` rejected on create and update
- a blank endpoint entry rejected
- zero and negative `syncInterval` rejected on create and update
- a valid positive `syncInterval` accepted
- empty `credentialsRef.name` rejected on create and update
- a fully valid spec accepted on create and update
- validation skipped when the object has a deletion timestamp, even with an otherwise-invalid spec

Ran and confirmed green:
- `go build ./...`
- `go vet ./...`
- `go test ./internal/webhook/...` (envtest suite, 12/12 specs pass)
- `golangci-lint run internal/webhook/v1/...` (0 issues)