### PR TITLE
fix(webhook): require a non-empty kubevirt name

### DIFF
--- a/internal/webhook/v1/validation.go
+++ b/internal/webhook/v1/validation.go
@@ -32,6 +32,9 @@ func validateProviderConfig(provider vrouterv1.ProviderConfig, namespace string)
 		if provider.KubeVirt == nil {
 			return fmt.Errorf("provider.kubevirt must be set when type is kubevirt")
 		}
+		if provider.KubeVirt.Name == "" {
+			return fmt.Errorf("provider.kubevirt.name must not be empty")
+		}
 	case vrouterv1.ProviderProxmox:
 		if provider.Proxmox == nil {
 			return fmt.Errorf("provider.proxmox must be set when type is proxmox")

--- a/internal/webhook/v1/validation_test.go
+++ b/internal/webhook/v1/validation_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"strings"
+	"testing"
+
+	vrouterv1 "github.com/tjjh89017/vrouter-operator/api/v1"
+)
+
+func TestValidateProviderConfig_KubeVirtName_Empty_Rejected(t *testing.T) {
+	provider := vrouterv1.ProviderConfig{
+		Type: vrouterv1.ProviderKubeVirt,
+		KubeVirt: &vrouterv1.KubeVirtConfig{
+			Name: "",
+		},
+	}
+
+	err := validateProviderConfig(provider, testNamespace)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "provider.kubevirt.name") {
+		t.Fatalf("error = %q, want it to mention provider.kubevirt.name", err.Error())
+	}
+}
+
+func TestValidateProviderConfig_KubeVirtName_Valid_Accepted(t *testing.T) {
+	provider := vrouterv1.ProviderConfig{
+		Type: vrouterv1.ProviderKubeVirt,
+		KubeVirt: &vrouterv1.KubeVirtConfig{
+			Name: "router-vm",
+		},
+	}
+
+	if err := validateProviderConfig(provider, testNamespace); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}


### PR DESCRIPTION
Based on #15. Please merge #15 first; this PR is stacked on top of it.

## Problem

The webhook that validates a provider config checked that `provider.kubevirt` is set, but it did not check that `provider.kubevirt.name` is not empty. A config like this passed both the CRD schema and the webhook:

```yaml
provider:
  type: kubevirt
  kubevirt:
    name: ""
```

The problem only showed up later, when the controller tried to find a virtual machine with an empty name. The config then got stuck in a failed state, and the user had no clear message from the webhook to explain why.

The proxmox and daemon provider branches in the same function already reject empty required fields at admission time. The kubevirt branch was missing this check.

## Fix

`validateProviderConfig` in `internal/webhook/v1/validation.go` now also rejects an empty `provider.kubevirt.name`, with a clear error message: `provider.kubevirt.name must not be empty`. This applies on both create and update, since the webhook runs the same validation function for both.

No API types or CRD manifests were changed. This is a webhook-only change.

## How tested

- Added `internal/webhook/v1/validation_test.go` with two new unit tests:
  - `TestValidateProviderConfig_KubeVirtName_Empty_Rejected` — an empty kubevirt name is rejected, and the error mentions `provider.kubevirt.name`.
  - `TestValidateProviderConfig_KubeVirtName_Valid_Accepted` — a valid non-empty name is accepted.
- Confirmed the existing cross-namespace clusterRef tests from #15 (`internal/webhook/v1/crossns_test.go`) still pass unchanged.
- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./internal/webhook/...` — all pass
- `make test` (full suite, envtest) — all pass, no generated-file drift
- `make lint` — 0 issues

## Test plan
- [x] Empty `kubevirt.name` is rejected on create
- [x] Empty `kubevirt.name` is rejected on update (same validation path)
- [x] Valid `kubevirt.name` is accepted
- [x] Cross-namespace clusterRef rejection from #15 still works