### PR TITLE
fix(webhook): block deletion of a referenced target

### DIFF
--- a/charts/vrouter-operator/templates/validating-webhook-configuration.yaml
+++ b/charts/vrouter-operator/templates/validating-webhook-configuration.yaml
@@ -84,6 +84,7 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    - DELETE
     resources:
     - vroutertargets
   sideEffects: None

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -187,6 +187,7 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    - DELETE
     resources:
     - vroutertargets
   sideEffects: None

--- a/internal/webhook/v1/vroutertarget_delete_test.go
+++ b/internal/webhook/v1/vroutertarget_delete_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	vrouterv1 "github.com/tjjh89017/vrouter-operator/api/v1"
+)
+
+// otherNamespace is used by the cross-namespace test case below; a binding
+// living here must never block deletion of a target in testNamespace, even
+// if it happens to reference a target with the same name (same-namespace-only
+// policy means such a reference could never resolve to this target anyway).
+const otherNamespace = "tenant-b"
+
+func TestCheckTargetNotReferenced_ReferencedByBinding_Rejected(t *testing.T) {
+	target := &vrouterv1.VRouterTarget{ObjectMeta: metaObj("r1")}
+	binding := &vrouterv1.VRouterBinding{
+		ObjectMeta: metaObj("b1"),
+		Spec: vrouterv1.VRouterBindingSpec{
+			TemplateRefs: []vrouterv1.NameRef{{Name: "tmpl1"}},
+			TargetRefs:   []vrouterv1.NameRef{{Name: "r1"}},
+		},
+	}
+	cl := newTestClient(t, target, binding)
+
+	err := checkTargetNotReferenced(context.Background(), cl, target)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), `still referenced by VRouterBinding "b1"`) {
+		t.Fatalf("error = %q, want it to name the referencing binding", err.Error())
+	}
+}
+
+func TestCheckTargetNotReferenced_ReferencedByConfig_Rejected(t *testing.T) {
+	target := &vrouterv1.VRouterTarget{ObjectMeta: metaObj("r1")}
+	cfg := &vrouterv1.VRouterConfig{
+		ObjectMeta: metaObj("c1"),
+		Spec: vrouterv1.VRouterConfigSpec{
+			TargetRef: vrouterv1.NameRef{Name: "r1"},
+		},
+	}
+	cl := newTestClient(t, target, cfg)
+
+	err := checkTargetNotReferenced(context.Background(), cl, target)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), `still referenced by VRouterConfig "c1"`) {
+		t.Fatalf("error = %q, want it to name the referencing config", err.Error())
+	}
+}
+
+func TestCheckTargetNotReferenced_Unreferenced_Allowed(t *testing.T) {
+	target := &vrouterv1.VRouterTarget{ObjectMeta: metaObj("r1")}
+	// A binding/config that reference a different target must not block r1.
+	other := &vrouterv1.VRouterTarget{ObjectMeta: metaObj("r2")}
+	binding := &vrouterv1.VRouterBinding{
+		ObjectMeta: metaObj("b1"),
+		Spec: vrouterv1.VRouterBindingSpec{
+			TemplateRefs: []vrouterv1.NameRef{{Name: "tmpl1"}},
+			TargetRefs:   []vrouterv1.NameRef{{Name: "r2"}},
+		},
+	}
+	cl := newTestClient(t, target, other, binding)
+
+	if err := checkTargetNotReferenced(context.Background(), cl, target); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestCheckTargetNotReferenced_DifferentNamespaceReference_Allowed(t *testing.T) {
+	target := &vrouterv1.VRouterTarget{ObjectMeta: metaObj("r1")}
+	// A binding in a different namespace that happens to reference the same
+	// name is not a real reference: same-namespace-only policy means it can
+	// only ever resolve to a target in its own namespace.
+	crossNSBinding := &vrouterv1.VRouterBinding{
+		ObjectMeta: metav1.ObjectMeta{Namespace: otherNamespace, Name: "b1"},
+		Spec: vrouterv1.VRouterBindingSpec{
+			TemplateRefs: []vrouterv1.NameRef{{Name: "tmpl1"}},
+			TargetRefs:   []vrouterv1.NameRef{{Name: "r1"}},
+		},
+	}
+	cl := newTestClient(t, target, crossNSBinding)
+
+	if err := checkTargetNotReferenced(context.Background(), cl, target); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestVRouterTargetCustomValidator_ValidateDelete_Referenced_Rejected(t *testing.T) {
+	target := &vrouterv1.VRouterTarget{ObjectMeta: metaObj("r1")}
+	binding := &vrouterv1.VRouterBinding{
+		ObjectMeta: metaObj("b1"),
+		Spec: vrouterv1.VRouterBindingSpec{
+			TemplateRefs: []vrouterv1.NameRef{{Name: "tmpl1"}},
+			TargetRefs:   []vrouterv1.NameRef{{Name: "r1"}},
+		},
+	}
+	cl := newTestClient(t, target, binding)
+	validator := &VRouterTargetCustomValidator{Client: cl}
+
+	_, err := validator.ValidateDelete(context.Background(), target)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), `still referenced by VRouterBinding "b1"`) {
+		t.Fatalf("error = %q, want it to name the referencing binding", err.Error())
+	}
+}
+
+func TestVRouterTargetCustomValidator_ValidateDelete_Unreferenced_Allowed(t *testing.T) {
+	target := &vrouterv1.VRouterTarget{ObjectMeta: metaObj("r1")}
+	cl := newTestClient(t, target)
+	validator := &VRouterTargetCustomValidator{Client: cl}
+
+	if _, err := validator.ValidateDelete(context.Background(), target); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}

--- a/internal/webhook/v1/vroutertarget_webhook.go
+++ b/internal/webhook/v1/vroutertarget_webhook.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -36,7 +37,7 @@ var vroutertargetlog = logf.Log.WithName("vroutertarget-resource")
 // SetupVRouterTargetWebhookWithManager registers the webhook for VRouterTarget in the manager.
 func SetupVRouterTargetWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).For(&vrouterv1.VRouterTarget{}).
-		WithValidator(&VRouterTargetCustomValidator{}).
+		WithValidator(&VRouterTargetCustomValidator{Client: mgr.GetClient()}).
 		WithDefaulter(&VRouterTargetCustomDefaulter{}).
 		Complete()
 }
@@ -68,10 +69,9 @@ func (d *VRouterTargetCustomDefaulter) Default(_ context.Context, obj runtime.Ob
 	return nil
 }
 
-// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 // NOTE: The 'path' attribute must follow a specific pattern and should not be modified directly here.
 // Modifying the path for an invalid path can cause API server errors; failing to locate the webhook.
-// +kubebuilder:webhook:path=/validate-vrouter-kojuro-date-v1-vroutertarget,mutating=false,failurePolicy=fail,sideEffects=None,groups=vrouter.kojuro.date,resources=vroutertargets,verbs=create;update,versions=v1,name=vvroutertarget-v1.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-vrouter-kojuro-date-v1-vroutertarget,mutating=false,failurePolicy=fail,sideEffects=None,groups=vrouter.kojuro.date,resources=vroutertargets,verbs=create;update;delete,versions=v1,name=vvroutertarget-v1.kb.io,admissionReviewVersions=v1
 
 // VRouterTargetCustomValidator struct is responsible for validating the VRouterTarget resource
 // when it is created, updated, or deleted.
@@ -79,7 +79,7 @@ func (d *VRouterTargetCustomDefaulter) Default(_ context.Context, obj runtime.Ob
 // NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
 // as this struct is used only for temporary operations and does not need to be deeply copied.
 type VRouterTargetCustomValidator struct {
-	// TODO(user): Add more fields as needed for validation
+	client.Client
 }
 
 var _ webhook.CustomValidator = &VRouterTargetCustomValidator{}
@@ -114,12 +114,69 @@ func (v *VRouterTargetCustomValidator) ValidateUpdate(_ context.Context, oldObj,
 }
 
 // ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type VRouterTarget.
-func (v *VRouterTargetCustomValidator) ValidateDelete(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+func (v *VRouterTargetCustomValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	vroutertarget, ok := obj.(*vrouterv1.VRouterTarget)
 	if !ok {
 		return nil, fmt.Errorf("expected a VRouterTarget object but got %T", obj)
 	}
 	vroutertargetlog.Info("Validation for VRouterTarget upon deletion", "name", vroutertarget.GetName())
 
-	return nil, nil
+	return nil, checkTargetNotReferenced(ctx, v.Client, vroutertarget)
+}
+
+// checkTargetNotReferenced rejects deletion of a VRouterTarget that is still
+// referenced by a VRouterBinding (spec.targetRefs) or a VRouterConfig
+// (spec.targetRef). References are resolved with the same-namespace-only
+// policy enforced elsewhere in this package, so only objects in the target's
+// own namespace can reference it; it is enough to list within that namespace.
+func checkTargetNotReferenced(ctx context.Context, cl client.Client, target *vrouterv1.VRouterTarget) error {
+	var bindingList vrouterv1.VRouterBindingList
+	if err := cl.List(ctx, &bindingList, client.InNamespace(target.Namespace)); err != nil {
+		return fmt.Errorf("list VRouterBindings: %w", err)
+	}
+
+	var referencingBindings []string
+	for _, binding := range bindingList.Items {
+		for _, ref := range binding.Spec.TargetRefs {
+			if ref.Name == target.Name && vrouterv1.ResolveNamespace(ref, binding.Namespace) == target.Namespace {
+				referencingBindings = append(referencingBindings, binding.Name)
+				break
+			}
+		}
+	}
+
+	var configList vrouterv1.VRouterConfigList
+	if err := cl.List(ctx, &configList, client.InNamespace(target.Namespace)); err != nil {
+		return fmt.Errorf("list VRouterConfigs: %w", err)
+	}
+
+	var referencingConfigs []string
+	for _, cfg := range configList.Items {
+		ref := cfg.Spec.TargetRef
+		if ref.Name == target.Name && vrouterv1.ResolveNamespace(ref, cfg.Namespace) == target.Namespace {
+			referencingConfigs = append(referencingConfigs, cfg.Name)
+		}
+	}
+
+	total := len(referencingBindings) + len(referencingConfigs)
+	if total == 0 {
+		return nil
+	}
+
+	// Name at least one referencing object of each kind found, and note how many more exist.
+	var first string
+	var kind string
+	switch {
+	case len(referencingBindings) > 0:
+		first = referencingBindings[0]
+		kind = "VRouterBinding"
+	default:
+		first = referencingConfigs[0]
+		kind = "VRouterConfig"
+	}
+
+	if total == 1 {
+		return fmt.Errorf("cannot delete VRouterTarget %q: still referenced by %s %q", target.Name, kind, first)
+	}
+	return fmt.Errorf("cannot delete VRouterTarget %q: still referenced by %s %q (and %d others)", target.Name, kind, first, total-1)
 }


### PR DESCRIPTION
Based on #15. Please merge #15 first. This branch has only one commit on top of it.

## Problem

If you delete a VRouterTarget that a VRouterBinding or VRouterConfig still points to, those objects get stuck. The webhook only checked references on create and update, not on delete. So after the target was gone, any later update to the binding or config was rejected with "targetRef not found". The binding kept failing with `Ready=False` and could not fix itself, even if you undid the change that triggered the update.

## Fix

`ValidateDelete` on VRouterTarget now checks if the target is still used. It looks for:
- Any VRouterBinding in the same namespace with this target in `spec.targetRefs`.
- Any VRouterConfig in the same namespace with this target in `spec.targetRef`.

If it finds one, the delete is rejected with an error that names at least one object that still uses the target, so the user knows what to remove or update first. If nothing uses the target, the delete goes through as before.

This follows the same-namespace-only rule already enforced by #15, so the check only needs to look in the target's own namespace.

The webhook config (`config/webhook/manifests.yaml` and the Helm chart's `validating-webhook-configuration.yaml`) is also updated to register the `DELETE` operation for this webhook, since without it the API server would never send delete requests to `ValidateDelete` in a real cluster.

## How this was tested

- New unit tests in `internal/webhook/v1/vroutertarget_delete_test.go`, using the same fake-client pattern as `crossns_test.go`:
  - A target referenced by a binding: delete is rejected, error names the binding.
  - A target referenced by a config: delete is rejected, error names the config.
  - An unreferenced target: delete is allowed.
  - A same-named target/binding pair in a different namespace: not treated as a reference (same-namespace-only), delete is allowed.
- `go build ./...`, `go vet ./...`, `go test ./internal/webhook/...` (no envtest binaries needed for these tests), `make lint` — all pass.