### PR TITLE
fix(controller): set Applied condition false while applying

### DIFF
--- a/internal/controller/vrouterconfig_applied_condition_test.go
+++ b/internal/controller/vrouterconfig_applied_condition_test.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+
+	vrouterv1 "github.com/tjjh89017/vrouter-operator/api/v1"
+	providertypes "github.com/tjjh89017/vrouter-operator/internal/provider/types"
+)
+
+// staticPidProvider is a minimal types.Provider stub whose ExecScript always
+// "succeeds" at dispatch, returning a fixed PID. It is only used to drive
+// applyConfig directly; GetExecStatus is never called in these tests.
+type staticPidProvider struct {
+	pid int64
+}
+
+func (staticPidProvider) IsVMRunning(_ context.Context) (bool, error) { return true, nil }
+func (staticPidProvider) CheckReady(_ context.Context) error          { return nil }
+func (p staticPidProvider) ExecScript(_ context.Context, _, _ string, _ bool) (int64, error) {
+	return p.pid, nil
+}
+func (staticPidProvider) GetExecStatus(_ context.Context, _ int64) (*providertypes.ExecStatus, error) {
+	return &providertypes.ExecStatus{Exited: false}, nil
+}
+
+// TestApplyConfig_NewGeneration_SetsAppliedFalse is the regression test for
+// C15: dispatching a new generation must not leave a stale Applied=True
+// condition from a previous generation in place. Without the fix,
+// `kubectl wait --for=condition=Applied` would return immediately against
+// the old True condition even though the newly dispatched script has not
+// run yet.
+func TestApplyConfig_NewGeneration_SetsAppliedFalse(t *testing.T) {
+	cfg := &vrouterv1.VRouterConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "c1", Namespace: "default", Generation: 2},
+		Spec: vrouterv1.VRouterConfigSpec{
+			TargetRef: vrouterv1.NameRef{Name: "r1"},
+			Config:    "set system host-name test",
+		},
+		Status: vrouterv1.VRouterConfigStatus{
+			Phase:              vrouterv1.PhaseApplied,
+			ObservedGeneration: 1,
+			Conditions: []metav1.Condition{
+				{
+					Type:               vrouterv1.ConditionApplied,
+					Status:             metav1.ConditionTrue,
+					Reason:             "ConfigApplied",
+					Message:            "Configuration applied successfully.",
+					ObservedGeneration: 1,
+					LastTransitionTime: metav1.Now(),
+				},
+			},
+		},
+	}
+
+	r, cl := newFakeReconciler(t, cfg)
+
+	if _, err := r.applyConfig(context.Background(), cfg, staticPidProvider{pid: 55}, nil); err != nil {
+		t.Fatalf("applyConfig returned error: %v", err)
+	}
+
+	if cfg.Status.Phase != vrouterv1.PhaseApplying {
+		t.Errorf("status.phase = %q, want %q", cfg.Status.Phase, vrouterv1.PhaseApplying)
+	}
+	if cfg.Status.ObservedGeneration != 2 {
+		t.Errorf("status.observedGeneration = %d, want 2 (the generation being dispatched)", cfg.Status.ObservedGeneration)
+	}
+
+	cond := findAppliedCondition(cfg.Status.Conditions)
+	if cond == nil {
+		t.Fatalf("expected an Applied condition to be set")
+	}
+	if cond.Status != metav1.ConditionFalse {
+		t.Errorf("Applied condition status = %q, want %q (stale True must not survive a new dispatch)", cond.Status, metav1.ConditionFalse)
+	}
+	if cond.ObservedGeneration != 2 {
+		t.Errorf("Applied condition observedGeneration = %d, want 2 (the generation being dispatched)", cond.ObservedGeneration)
+	}
+
+	// The persisted object (via the status patch) must reflect the same thing.
+	var got vrouterv1.VRouterConfig
+	if err := cl.Get(context.Background(), k8stypes.NamespacedName{Name: "c1", Namespace: "default"}, &got); err != nil {
+		t.Fatalf("get updated config: %v", err)
+	}
+	persistedCond := findAppliedCondition(got.Status.Conditions)
+	if persistedCond == nil || persistedCond.Status != metav1.ConditionFalse {
+		t.Errorf("persisted Applied condition = %+v, want status False", persistedCond)
+	}
+}
+
+// TestPollExecStatus_Success_StampsAppliedTrueWithDispatchedGeneration
+// verifies that once the dispatched exec exits successfully, Applied=True
+// is stamped with the generation the exec was actually dispatched for
+// (status.observedGeneration), which in the common case (no mid-run spec
+// edit) equals cfg.Generation.
+func TestPollExecStatus_Success_StampsAppliedTrueWithDispatchedGeneration(t *testing.T) {
+	cfg := &vrouterv1.VRouterConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "c1", Namespace: "default", Generation: 3},
+		Spec: vrouterv1.VRouterConfigSpec{
+			TargetRef: vrouterv1.NameRef{Name: "r1"},
+			Config:    "set system host-name test",
+		},
+		Status: vrouterv1.VRouterConfigStatus{
+			Phase:              vrouterv1.PhaseApplying,
+			ExecPID:            42,
+			ObservedGeneration: 3,
+		},
+	}
+
+	r, cl := newFakeReconciler(t, cfg)
+
+	if _, err := r.pollExecStatus(context.Background(), cfg, fakeExitedProvider{exitCode: 0}); err != nil {
+		t.Fatalf("pollExecStatus returned error: %v", err)
+	}
+
+	if cfg.Status.Phase != vrouterv1.PhaseApplied {
+		t.Errorf("status.phase = %q, want %q", cfg.Status.Phase, vrouterv1.PhaseApplied)
+	}
+
+	cond := findAppliedCondition(cfg.Status.Conditions)
+	if cond == nil {
+		t.Fatalf("expected an Applied condition to be set")
+	}
+	if cond.Status != metav1.ConditionTrue {
+		t.Errorf("Applied condition status = %q, want %q", cond.Status, metav1.ConditionTrue)
+	}
+	if cond.ObservedGeneration != cfg.Status.ObservedGeneration {
+		t.Errorf("Applied condition observedGeneration = %d, want %d (status.observedGeneration at completion time)", cond.ObservedGeneration, cfg.Status.ObservedGeneration)
+	}
+
+	var got vrouterv1.VRouterConfig
+	if err := cl.Get(context.Background(), k8stypes.NamespacedName{Name: "c1", Namespace: "default"}, &got); err != nil {
+		t.Fatalf("get updated config: %v", err)
+	}
+	if persistedCond := findAppliedCondition(got.Status.Conditions); persistedCond == nil || persistedCond.ObservedGeneration != 3 {
+		t.Errorf("persisted Applied condition = %+v, want observedGeneration 3", persistedCond)
+	}
+}
+
+// TestPollExecStatus_MidRunGenerationBump_DoesNotStampNeverAppliedGeneration
+// covers the "related" part of C15: if the spec is edited while a script is
+// still running, cfg.Generation moves ahead of the generation the running
+// exec was actually dispatched for. When that exec finishes, the completed
+// exec must stamp the Applied condition with the generation it was
+// dispatched for (status.observedGeneration), not the newer, never-applied
+// cfg.Generation.
+func TestPollExecStatus_MidRunGenerationBump_DoesNotStampNeverAppliedGeneration(t *testing.T) {
+	cfg := &vrouterv1.VRouterConfig{
+		// The spec was edited after dispatch: cfg.Generation (4) has moved
+		// ahead of status.ObservedGeneration (3), the generation this
+		// in-flight exec was actually dispatched for.
+		ObjectMeta: metav1.ObjectMeta{Name: "c1", Namespace: "default", Generation: 4},
+		Spec: vrouterv1.VRouterConfigSpec{
+			TargetRef: vrouterv1.NameRef{Name: "r1"},
+			Config:    "set system host-name test",
+		},
+		Status: vrouterv1.VRouterConfigStatus{
+			Phase:              vrouterv1.PhaseApplying,
+			ExecPID:            42,
+			ObservedGeneration: 3,
+		},
+	}
+
+	r, _ := newFakeReconciler(t, cfg)
+
+	if _, err := r.pollExecStatus(context.Background(), cfg, fakeExitedProvider{exitCode: 0}); err != nil {
+		t.Fatalf("pollExecStatus returned error: %v", err)
+	}
+
+	cond := findAppliedCondition(cfg.Status.Conditions)
+	if cond == nil {
+		t.Fatalf("expected an Applied condition to be set")
+	}
+	if cond.ObservedGeneration != 3 {
+		t.Errorf("Applied condition observedGeneration = %d, want 3 (the generation this exec was dispatched for, not cfg.Generation=4 which was never applied)", cond.ObservedGeneration)
+	}
+	if cond.ObservedGeneration == cfg.Generation {
+		t.Errorf("Applied condition observedGeneration must not equal the never-applied cfg.Generation (%d)", cfg.Generation)
+	}
+}

--- a/internal/controller/vrouterconfig_controller.go
+++ b/internal/controller/vrouterconfig_controller.go
@@ -234,7 +234,7 @@ func (r *VRouterConfigReconciler) pollExecStatus(ctx context.Context, cfg *vrout
 				Status:             metav1.ConditionFalse,
 				Reason:             "ApplyTimeout",
 				Message:            cfg.Status.Message,
-				ObservedGeneration: cfg.Generation,
+				ObservedGeneration: cfg.Status.ObservedGeneration,
 			})
 			return ctrl.Result{}, r.Status().Patch(ctx, cfg, patch)
 		}
@@ -251,6 +251,12 @@ func (r *VRouterConfigReconciler) pollExecStatus(ctx context.Context, cfg *vrout
 	patch := client.MergeFrom(cfg.DeepCopy())
 	cfg.Status.ExecPID = 0
 	cfg.Status.ExecStartedTime = nil
+	// Stamp the condition with status.ObservedGeneration -- the generation
+	// this exec was dispatched for in applyConfig -- rather than the current
+	// cfg.Generation. If the spec changed while the script was running,
+	// cfg.Generation may already have moved on to a generation that was
+	// never actually applied; the exec that just finished only speaks for
+	// the generation it was dispatched for.
 	if status.ExitCode == 0 {
 		now := metav1.Now()
 		cfg.Status.Phase = vrouterv1.PhaseApplied
@@ -261,7 +267,7 @@ func (r *VRouterConfigReconciler) pollExecStatus(ctx context.Context, cfg *vrout
 			Status:             metav1.ConditionTrue,
 			Reason:             "ConfigApplied",
 			Message:            "Configuration applied successfully.",
-			ObservedGeneration: cfg.Generation,
+			ObservedGeneration: cfg.Status.ObservedGeneration,
 		})
 		log.Info("config applied successfully")
 	} else {
@@ -272,7 +278,7 @@ func (r *VRouterConfigReconciler) pollExecStatus(ctx context.Context, cfg *vrout
 			Status:             metav1.ConditionFalse,
 			Reason:             "ConfigFailed",
 			Message:            cfg.Status.Message,
-			ObservedGeneration: cfg.Generation,
+			ObservedGeneration: cfg.Status.ObservedGeneration,
 		})
 		log.Info("config apply failed", "exitCode", status.ExitCode, "stderr", status.Stderr)
 	}
@@ -299,8 +305,20 @@ func (r *VRouterConfigReconciler) applyConfig(ctx context.Context, cfg *vrouterv
 	cfg.Status.ExecStartedTime = &now
 	cfg.Status.ObservedGeneration = cfg.Generation
 	cfg.Status.Phase = vrouterv1.PhaseApplying
-	cfg.Status.Message = ""
+	cfg.Status.Message = fmt.Sprintf("applying generation %d", cfg.Generation)
 	cfg.Status.LastRebootHandledTime = targetRebootTime
+	// A new generation is being dispatched, so any previous Applied=True
+	// condition is now stale (it describes a generation that is no longer
+	// current). Mark Applied=False for the generation being dispatched here
+	// so `kubectl wait --for=condition=Applied` does not return early against
+	// the old True condition while the new script is still running.
+	meta.SetStatusCondition(&cfg.Status.Conditions, metav1.Condition{
+		Type:               vrouterv1.ConditionApplied,
+		Status:             metav1.ConditionFalse,
+		Reason:             "Applying",
+		Message:            cfg.Status.Message,
+		ObservedGeneration: cfg.Status.ObservedGeneration,
+	})
 	if err := r.Status().Patch(ctx, cfg, patch); err != nil {
 		return ctrl.Result{}, err
 	}


### PR DESCRIPTION
Based on #20. Please merge #16, #17, #19, and #20 first — this branch stacks on top of them because they all touch `vrouterconfig_controller.go`.

## Problem

When the controller starts applying a new generation of a config, it did not clear the old `Applied` condition. So if a config was `Applied=True` before, and the user then edited the spec, the condition stayed `True` while the new script was still running.

This means `kubectl wait --for=condition=Applied` returned right away, even though the new config had not actually been applied to the router yet.

There was a smaller related bug too: when a script finished, the code stamped the `Applied` condition with the *current* spec generation. If the spec changed again while the script was still running, the finished script would get reported as having applied a generation it never actually ran.

## Fix

- `applyConfig` now sets `Applied=False` (reason `Applying`) at the moment it dispatches a new generation. It uses the same generation number that gets written to `status.observedGeneration`, so the condition and the status field always agree.
- `pollExecStatus` now stamps the condition (on success, failure, or timeout) using `status.observedGeneration` — the generation the finished script was dispatched for — instead of the current spec generation.

This does not change the existing Failed / ApplyTimeout behavior, and does not touch the lost-exec-result recovery or reboot dedupe logic from the earlier PRs in this stack.

## How tested

Added `internal/controller/vrouterconfig_applied_condition_test.go`, using the same fake-provider seam as the other `vrouterconfig_*_test.go` files:

- `TestApplyConfig_NewGeneration_SetsAppliedFalse` — a config that was `Applied=True` gets a new generation dispatched; after `applyConfig`, `Applied` is `False` and phase is `Applying`. Confirmed this test fails without the fix (stale `True` condition).
- `TestPollExecStatus_Success_StampsAppliedTrueWithDispatchedGeneration` — after the exec finishes, `Applied=True` is stamped with the generation that was actually applied.
- `TestPollExecStatus_MidRunGenerationBump_DoesNotStampNeverAppliedGeneration` — if the spec generation moves ahead while a script is still running, the finished script's condition is stamped with the generation it was dispatched for, not the newer, never-applied one.

Ran:
- `go build ./...` — pass
- `go vet ./...` — pass
- `go test $(go list ./... | grep -v /e2e)` (envtest, `KUBEBUILDER_ASSETS` pointed at an absolute `bin/k8s/...` path) — pass
- `bin/golangci-lint run ./...` — 0 issues