### PR TITLE
fix(controller): clear proxmox node when the vm is gone

### DIFF
--- a/internal/controller/proxmoxcluster_controller.go
+++ b/internal/controller/proxmoxcluster_controller.go
@@ -150,31 +150,39 @@ func (r *ProxmoxClusterReconciler) onChange(ctx context.Context, _ ctrl.Request,
 			continue
 		}
 
-		info, ok := vmMap[px.VMID]
-		if !ok {
-			continue
-		}
+		// info is the zero value (node == "") when the VMID is absent from
+		// the freshly fetched resource list, e.g. the VM was destroyed. found
+		// distinguishes that case from an actual match, since reboot
+		// detection below only makes sense for a VM that is currently listed.
+		info, found := vmMap[px.VMID]
 
 		patch := client.MergeFrom(t.DeepCopy())
 		changed := false
 
-		if t.Status.ProxmoxNode != info.node {
-			t.Status.ProxmoxNode = info.node
+		// SPEC §7.3 4a: clear a stale node instead of leaving it when the VM
+		// is no longer reported by /cluster/resources. A stale node can make
+		// the provider's cached-node fallback (resolveNode) target the wrong
+		// host if the VMID is later reused on a different node.
+		if desiredProxmoxNode(vmMap, px.VMID) != t.Status.ProxmoxNode {
+			t.Status.ProxmoxNode = desiredProxmoxNode(vmMap, px.VMID)
 			changed = true
 		}
-		// Reboot detection via Proxmox-level uptime (detects hard restart only).
-		if info.uptime > 0 && info.uptime <= threshold {
-			t.Status.LastRebootTime = &now
-			changed = true
-		}
-		// Reboot detection via guest OS uptime through QGA (detects soft reboot too).
-		if vrouterv1.BoolValue(cluster.Spec.CheckGuestUptime, true) && info.node != "" {
-			guestUptime, err := r.fetchGuestUptime(ctx, cluster, info.node, px.VMID, tokenID, tokenSecret)
-			if err != nil {
-				log.Info("fetch guest uptime skipped", "target", t.Name, "reason", err.Error())
-			} else if guestUptime > 0 && guestUptime <= threshold {
+
+		if found {
+			// Reboot detection via Proxmox-level uptime (detects hard restart only).
+			if info.uptime > 0 && info.uptime <= threshold {
 				t.Status.LastRebootTime = &now
 				changed = true
+			}
+			// Reboot detection via guest OS uptime through QGA (detects soft reboot too).
+			if vrouterv1.BoolValue(cluster.Spec.CheckGuestUptime, true) && info.node != "" {
+				guestUptime, err := r.fetchGuestUptime(ctx, cluster, info.node, px.VMID, tokenID, tokenSecret)
+				if err != nil {
+					log.Info("fetch guest uptime skipped", "target", t.Name, "reason", err.Error())
+				} else if guestUptime > 0 && guestUptime <= threshold {
+					t.Status.LastRebootTime = &now
+					changed = true
+				}
 			}
 		}
 
@@ -205,6 +213,15 @@ func (r *ProxmoxClusterReconciler) onChange(ctx context.Context, _ ctrl.Request,
 type vmInfo struct {
 	node   string
 	uptime float64
+}
+
+// desiredProxmoxNode returns the node a VRouterTarget's status.proxmoxNode
+// should be set to, given the cluster resources fetched in this sync and the
+// target's VMID. If vmid is not present in vmMap (the VM was destroyed, not
+// yet created, or moved away), it returns "" so any previously cached node
+// is cleared rather than left stale. See SPEC.md §7.3 step 4a.
+func desiredProxmoxNode(vmMap map[int]vmInfo, vmid int) string {
+	return vmMap[vmid].node
 }
 
 // fetchClusterResources calls /api2/json/cluster/resources?type=vm and returns a map of VMID → vmInfo.

--- a/internal/controller/proxmoxcluster_controller_node_test.go
+++ b/internal/controller/proxmoxcluster_controller_node_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import "testing"
+
+// TestDesiredProxmoxNode_VMIDPresent verifies that when the VMID is listed
+// in the freshly fetched cluster resources, its node is returned.
+func TestDesiredProxmoxNode_VMIDPresent(t *testing.T) {
+	vmMap := map[int]vmInfo{
+		100: {node: "pve1", uptime: 3600},
+	}
+
+	got := desiredProxmoxNode(vmMap, 100)
+
+	if got != "pve1" {
+		t.Fatalf("desiredProxmoxNode() = %q, want %q", got, "pve1")
+	}
+}
+
+// TestDesiredProxmoxNode_VMIDAbsent verifies that when the VMID is absent
+// from a successfully fetched cluster resource list (e.g. the VM was
+// destroyed), the desired node is "" so a previously cached node gets
+// cleared instead of left stale (SPEC.md §7.3 step 4a). This guards against
+// the provider's cached-node fallback resolving to a now-wrong host after
+// the VMID is reused on a different node.
+func TestDesiredProxmoxNode_VMIDAbsent(t *testing.T) {
+	vmMap := map[int]vmInfo{
+		200: {node: "pve2", uptime: 100},
+	}
+
+	// VMID 100 is not in the list at all, simulating a destroyed VM whose
+	// target still carries a stale node from a previous sync.
+	got := desiredProxmoxNode(vmMap, 100)
+
+	if got != "" {
+		t.Fatalf("desiredProxmoxNode() = %q, want empty string when VMID is absent", got)
+	}
+}
+
+// TestDesiredProxmoxNode_EmptyMap verifies the same clearing behavior when
+// the resource list is empty (all VMs gone) rather than merely missing one
+// entry.
+func TestDesiredProxmoxNode_EmptyMap(t *testing.T) {
+	vmMap := map[int]vmInfo{}
+
+	got := desiredProxmoxNode(vmMap, 100)
+
+	if got != "" {
+		t.Fatalf("desiredProxmoxNode() = %q, want empty string for empty vmMap", got)
+	}
+}


### PR DESCRIPTION
Based on #16. Reviewers should merge #16 first.

## Problem

The sync loop in `proxmoxcluster_controller.go` reads the Proxmox
`/cluster/resources` list and matches each target's VMID against it. When a
VMID was not found, the code just skipped the target (`continue`) and kept
the old `status.proxmoxNode` value.

If a virtual machine is destroyed and later recreated with the same VMID on
a different node, the saved node name stays wrong until the next successful
match. During that window, the provider uses the stale cached node instead
of doing a live lookup, so guest agent calls go to the wrong host and fail.

This matches SPEC.md §7.3 step 4a, which says the node should be set to `""`
when the VMID is not found.

## Fix

When a target's VMID is not in the freshly fetched resource list,
`status.proxmoxNode` is now cleared to `""` and patched, instead of being
left as-is. This only happens when the resource list was fetched
successfully — a failed API call is treated as transient and does not touch
any target status (that path already returns earlier in the function).

The node lookup was pulled into a small pure function,
`desiredProxmoxNode(vmMap, vmid)`, so it can be unit tested without
`envtest`.

## How tested

- New unit tests in `internal/controller/proxmoxcluster_controller_node_test.go`:
  - VMID present in resources -> returns that node.
  - VMID absent from resources -> returns `""`.
  - Empty resource map -> returns `""`.
- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./internal/controller/...` (with `KUBEBUILDER_ASSETS`) — all pass, including the existing Ginkgo suite
- `make lint` — 0 issues