### PR TITLE
fix(controller): stamp reboot time once per reboot

### DIFF
--- a/internal/controller/proxmoxcluster_controller.go
+++ b/internal/controller/proxmoxcluster_controller.go
@@ -171,8 +171,10 @@ func (r *ProxmoxClusterReconciler) onChange(ctx context.Context, _ ctrl.Request,
 		if found {
 			// Reboot detection via Proxmox-level uptime (detects hard restart only).
 			if info.uptime > 0 && info.uptime <= threshold {
-				t.Status.LastRebootTime = &now
-				changed = true
+				if rt := nextRebootTime(now.Time, secondsToDuration(info.uptime), t.Status.LastRebootTime); rt != nil {
+					t.Status.LastRebootTime = rt
+					changed = true
+				}
 			}
 			// Reboot detection via guest OS uptime through QGA (detects soft reboot too).
 			if vrouterv1.BoolValue(cluster.Spec.CheckGuestUptime, true) && info.node != "" {
@@ -180,8 +182,10 @@ func (r *ProxmoxClusterReconciler) onChange(ctx context.Context, _ ctrl.Request,
 				if err != nil {
 					log.Info("fetch guest uptime skipped", "target", t.Name, "reason", err.Error())
 				} else if guestUptime > 0 && guestUptime <= threshold {
-					t.Status.LastRebootTime = &now
-					changed = true
+					if rt := nextRebootTime(now.Time, secondsToDuration(guestUptime), t.Status.LastRebootTime); rt != nil {
+						t.Status.LastRebootTime = rt
+						changed = true
+					}
 				}
 			}
 		}
@@ -222,6 +226,44 @@ type vmInfo struct {
 // is cleared rather than left stale. See SPEC.md §7.3 step 4a.
 func desiredProxmoxNode(vmMap map[int]vmInfo, vmid int) string {
 	return vmMap[vmid].node
+}
+
+// rebootTimeTolerance absorbs uptime second-granularity jitter and small
+// clock/scheduling skew between syncs so that a later sync observed within
+// the SAME reboot's low-uptime window is not mistaken for a new reboot.
+const rebootTimeTolerance = 5 * time.Second
+
+// secondsToDuration converts a Proxmox/guest uptime value, reported in
+// fractional seconds, to a time.Duration.
+func secondsToDuration(seconds float64) time.Duration {
+	return time.Duration(seconds * float64(time.Second))
+}
+
+// nextRebootTime decides whether a freshly observed low uptime represents a
+// genuinely new reboot and, if so, what value status.LastRebootTime should
+// be updated to.
+//
+// now is the time the uptime was observed, uptime is the reported guest/
+// Proxmox uptime at that moment, and current is the target's currently
+// stored LastRebootTime (nil if never set). The reboot instant is derived as
+// bootTime = now - uptime rather than stamped as `now`, so repeated syncs
+// during the same reboot's low-uptime window derive (approximately) the same
+// bootTime instead of drifting forward on every sync.
+//
+// It returns nil ("no update needed") when current is already within
+// rebootTimeTolerance of the derived bootTime, i.e. this observation is
+// still part of the same reboot as the one already recorded. Otherwise it
+// returns a *metav1.Time set to the derived bootTime: either because no
+// reboot was recorded yet (current == nil), or because bootTime is more than
+// rebootTimeTolerance newer than current, indicating a genuinely new reboot
+// happened.
+func nextRebootTime(now time.Time, uptime time.Duration, current *metav1.Time) *metav1.Time {
+	bootTime := now.Add(-uptime)
+	if current != nil && bootTime.Sub(current.Time) <= rebootTimeTolerance {
+		return nil
+	}
+	t := metav1.NewTime(bootTime)
+	return &t
 }
 
 // fetchClusterResources calls /api2/json/cluster/resources?type=vm and returns a map of VMID → vmInfo.

--- a/internal/controller/proxmoxcluster_controller_reboot_test.go
+++ b/internal/controller/proxmoxcluster_controller_reboot_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestNextRebootTime_NoStoredValue verifies that when a target has never had
+// a reboot recorded, a low uptime observation always sets LastRebootTime to
+// the derived boot time (now - uptime), not to `now` itself.
+func TestNextRebootTime_NoStoredValue(t *testing.T) {
+	now := time.Date(2026, 7, 3, 0, 0, 30, 0, time.UTC) // t=30
+	uptime := 30 * time.Second                          // rebooted at t=0
+
+	got := nextRebootTime(now, uptime, nil)
+
+	if got == nil {
+		t.Fatalf("nextRebootTime() = nil, want non-nil boot time")
+	}
+	wantBootTime := now.Add(-uptime)
+	if !got.Time.Equal(wantBootTime) {
+		t.Fatalf("nextRebootTime() = %v, want %v", got.Time, wantBootTime)
+	}
+}
+
+// TestNextRebootTime_SameRebootWindow verifies the C17 scenario: a later
+// sync within the SAME reboot's low-uptime window derives (approximately)
+// the same boot time as an earlier sync and must NOT advance
+// LastRebootTime, even though `now` has moved forward.
+func TestNextRebootTime_SameRebootWindow(t *testing.T) {
+	rebootedAt := time.Date(2026, 7, 3, 0, 0, 0, 0, time.UTC) // t=0
+
+	// First sync at t=30: uptime=30s -> derived bootTime = t0.
+	firstSyncNow := rebootedAt.Add(30 * time.Second)
+	stored := nextRebootTime(firstSyncNow, 30*time.Second, nil)
+	if stored == nil {
+		t.Fatalf("first sync: nextRebootTime() = nil, want non-nil")
+	}
+
+	// Second sync at t=80 (still within the 90s threshold window):
+	// uptime=80s -> derived bootTime = t0 again (same physical reboot).
+	secondSyncNow := rebootedAt.Add(80 * time.Second)
+	got := nextRebootTime(secondSyncNow, 80*time.Second, stored)
+
+	if got != nil {
+		t.Fatalf("second sync: nextRebootTime() = %v, want nil (unchanged, same reboot window)", got.Time)
+	}
+}
+
+// TestNextRebootTime_NewerReboot verifies that a genuinely new reboot -
+// derived boot time more than the tolerance newer than the stored value -
+// still advances LastRebootTime.
+func TestNextRebootTime_NewerReboot(t *testing.T) {
+	firstReboot := time.Date(2026, 7, 3, 0, 0, 0, 0, time.UTC) // t=0
+	stored := metav1.NewTime(firstReboot)
+
+	// A second, later reboot: VM rebooted again at t=500, observed at t=520
+	// with uptime=20s -> derived bootTime = t=500, well beyond tolerance.
+	secondRebootObservedAt := firstReboot.Add(520 * time.Second)
+	uptime := 20 * time.Second
+
+	got := nextRebootTime(secondRebootObservedAt, uptime, &stored)
+
+	if got == nil {
+		t.Fatalf("nextRebootTime() = nil, want non-nil for a genuinely new reboot")
+	}
+	wantBootTime := secondRebootObservedAt.Add(-uptime)
+	if !got.Time.Equal(wantBootTime) {
+		t.Fatalf("nextRebootTime() = %v, want %v", got.Time, wantBootTime)
+	}
+}
+
+// TestNextRebootTime_WithinToleranceJitter verifies that a derived boot time
+// that is only slightly newer than the stored value (within tolerance, e.g.
+// from second-granularity uptime rounding) is treated as the same reboot.
+func TestNextRebootTime_WithinToleranceJitter(t *testing.T) {
+	rebootedAt := time.Date(2026, 7, 3, 0, 0, 0, 0, time.UTC)
+	stored := metav1.NewTime(rebootedAt)
+
+	// Derived boot time is 2s newer than stored, well within the 5s
+	// tolerance - should be treated as jitter from the same reboot.
+	now := rebootedAt.Add(2*time.Second + 10*time.Second)
+	uptime := 10 * time.Second
+
+	got := nextRebootTime(now, uptime, &stored)
+
+	if got != nil {
+		t.Fatalf("nextRebootTime() = %v, want nil (within tolerance jitter)", got.Time)
+	}
+}
+
+// TestNextRebootTime_DerivedBootTimeOlderThanStored verifies that clock
+// skew or measurement noise producing a derived boot time OLDER than the
+// stored value does not regress LastRebootTime backwards.
+func TestNextRebootTime_DerivedBootTimeOlderThanStored(t *testing.T) {
+	rebootedAt := time.Date(2026, 7, 3, 0, 0, 30, 0, time.UTC)
+	stored := metav1.NewTime(rebootedAt)
+
+	// Derived boot time is 1s OLDER than stored (negative diff).
+	now := rebootedAt.Add(-1*time.Second + 10*time.Second)
+	uptime := 10 * time.Second
+
+	got := nextRebootTime(now, uptime, &stored)
+
+	if got != nil {
+		t.Fatalf("nextRebootTime() = %v, want nil (derived boot time not newer than stored)", got.Time)
+	}
+}


### PR DESCRIPTION
Based on #26. Please merge #16 and #26 first.

## Problem

When a router restarted, the operator checked the guest uptime on every sync. As long as the uptime stayed low (below about 1.5 times the sync interval), it kept setting `status.lastRebootTime` to the current time on each sync, not just once.

This mattered because the config controller treats a newer `lastRebootTime` as a new reboot and force-re-applies the full config. So one real reboot could cause the config to be re-applied more than once.

Example with the default 60s sync interval (90s threshold): the VM reboots at t=0. The sync at t=30 sets `lastRebootTime` and the config is re-applied. The sync at t=80 still sees uptime under the 90s threshold, so it sets `lastRebootTime` again to a newer time, and the same config is force-re-applied a second time for the same reboot.

## Fix

Instead of stamping `lastRebootTime` with "now", the code now works out the boot time (`now` minus uptime) and only updates `lastRebootTime` when that boot time is clearly newer than the value already stored. A small tolerance absorbs normal jitter from uptime being reported in whole seconds and small clock differences. This way, each physical reboot settles on one stable boot time and is recorded once, so the config controller re-applies exactly once per reboot.

The node-clearing behavior from #26 and the other sync logic (guest uptime check flag, marking targets stopped, and so on) are unchanged.

## How tested

- Added `internal/controller/proxmoxcluster_controller_reboot_test.go` with unit tests for the new `nextRebootTime` helper: no stored value yet, a later sync in the same reboot window (should not change), a genuinely new reboot (should change), small jitter within tolerance (should not change), and a derived time older than the stored one (should not change).
- `go build ./...`
- `go vet ./...`
- `go test ./internal/controller/...` (envtest, all tests pass)
- `make lint` (0 issues)