### PR TITLE
fix(api): add minimum bounds for vmid and timeout

### DIFF
--- a/api/v1/daemon_types.go
+++ b/api/v1/daemon_types.go
@@ -28,5 +28,6 @@ type DaemonConfig struct {
 	// TimeoutSeconds is the maximum time to wait for a config apply to complete.
 	// +optional
 	// +kubebuilder:default=60
+	// +kubebuilder:validation:Minimum=1
 	TimeoutSeconds int32 `json:"timeoutSeconds,omitempty"`
 }

--- a/api/v1/proxmox_types.go
+++ b/api/v1/proxmox_types.go
@@ -21,6 +21,7 @@ const ProviderProxmox ProviderType = "proxmox"
 // ProxmoxConfig holds Proxmox VE provider configuration and router identification.
 type ProxmoxConfig struct {
 	// VMID of the virtual machine on Proxmox.
+	// +kubebuilder:validation:Minimum=100
 	VMID int `json:"vmid"`
 	// ClusterRef references a ProxmoxCluster resource that holds endpoint and credentials.
 	// Namespace may be omitted to use the same namespace as the VRouterTarget.

--- a/charts/vrouter-operator/templates/vroutertarget-crd.yaml
+++ b/charts/vrouter-operator/templates/vroutertarget-crd.yaml
@@ -71,6 +71,7 @@ spec:
                         description: TimeoutSeconds is the maximum time to wait for
                           a config apply to complete.
                         format: int32
+                        minimum: 1
                         type: integer
                     required:
                     - address
@@ -125,6 +126,7 @@ spec:
                         type: object
                       vmid:
                         description: VMID of the virtual machine on Proxmox.
+                        minimum: 100
                         type: integer
                     required:
                     - clusterRef

--- a/config/crd/bases/vrouter.kojuro.date_vroutertargets.yaml
+++ b/config/crd/bases/vrouter.kojuro.date_vroutertargets.yaml
@@ -70,6 +70,7 @@ spec:
                         description: TimeoutSeconds is the maximum time to wait for
                           a config apply to complete.
                         format: int32
+                        minimum: 1
                         type: integer
                     required:
                     - address
@@ -124,6 +125,7 @@ spec:
                         type: object
                       vmid:
                         description: VMID of the virtual machine on Proxmox.
+                        minimum: 100
                         type: integer
                     required:
                     - clusterRef

--- a/internal/controller/vroutertarget_numeric_bounds_test.go
+++ b/internal/controller/vroutertarget_numeric_bounds_test.go
@@ -1,0 +1,196 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	vrouterv1 "github.com/tjjh89017/vrouter-operator/api/v1"
+)
+
+// These tests confirm that the Kubernetes API server rejects VRouterTarget
+// resources with out-of-range numeric fields, based on the CRD schema
+// generated from the +kubebuilder:validation:Minimum markers on
+// ProxmoxConfig.VMID and DaemonConfig.TimeoutSeconds. A VMID below 100 is
+// never a valid Proxmox VM ID, and a non-positive TimeoutSeconds cannot
+// describe a wait duration.
+var _ = Describe("VRouterTarget numeric bounds", func() {
+	Context("proxmox.vmid", func() {
+		It("should reject a vmid of 0", func() {
+			target := &vrouterv1.VRouterTarget{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "bounds-vmid-zero-",
+					Namespace:    "default",
+				},
+				Spec: vrouterv1.VRouterTargetSpec{
+					Provider: vrouterv1.ProviderConfig{
+						Type: vrouterv1.ProviderProxmox,
+						Proxmox: &vrouterv1.ProxmoxConfig{
+							VMID:       0,
+							ClusterRef: vrouterv1.NameRef{Name: "cluster"},
+						},
+					},
+				},
+			}
+			err := k8sClient.Create(ctx, target)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("vmid"))
+		})
+
+		It("should reject a vmid of 99 (below the valid Proxmox range)", func() {
+			target := &vrouterv1.VRouterTarget{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "bounds-vmid-99-",
+					Namespace:    "default",
+				},
+				Spec: vrouterv1.VRouterTargetSpec{
+					Provider: vrouterv1.ProviderConfig{
+						Type: vrouterv1.ProviderProxmox,
+						Proxmox: &vrouterv1.ProxmoxConfig{
+							VMID:       99,
+							ClusterRef: vrouterv1.NameRef{Name: "cluster"},
+						},
+					},
+				},
+			}
+			err := k8sClient.Create(ctx, target)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("vmid"))
+		})
+
+		It("should reject a negative vmid", func() {
+			target := &vrouterv1.VRouterTarget{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "bounds-vmid-negative-",
+					Namespace:    "default",
+				},
+				Spec: vrouterv1.VRouterTargetSpec{
+					Provider: vrouterv1.ProviderConfig{
+						Type: vrouterv1.ProviderProxmox,
+						Proxmox: &vrouterv1.ProxmoxConfig{
+							VMID:       -1,
+							ClusterRef: vrouterv1.NameRef{Name: "cluster"},
+						},
+					},
+				},
+			}
+			err := k8sClient.Create(ctx, target)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("vmid"))
+		})
+
+		It("should admit the minimum valid vmid of 100", func() {
+			target := &vrouterv1.VRouterTarget{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "bounds-vmid-100-",
+					Namespace:    "default",
+				},
+				Spec: vrouterv1.VRouterTargetSpec{
+					Provider: vrouterv1.ProviderConfig{
+						Type: vrouterv1.ProviderProxmox,
+						Proxmox: &vrouterv1.ProxmoxConfig{
+							VMID:       100,
+							ClusterRef: vrouterv1.NameRef{Name: "cluster"},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, target)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, target)).To(Succeed())
+		})
+	})
+
+	Context("daemon.timeoutSeconds", func() {
+		It("should reject a timeoutSeconds of 0", func() {
+			// TimeoutSeconds is `json:"timeoutSeconds,omitempty"`, so a typed
+			// Go client would silently drop an explicit 0 (the Go zero value)
+			// before it reaches the API server, letting the default of 60
+			// apply instead. Use an unstructured object to put a literal 0
+			// on the wire and confirm the API server itself rejects it.
+			target := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "vrouter.kojuro.date/v1",
+					"kind":       "VRouterTarget",
+					"metadata": map[string]interface{}{
+						"generateName": "bounds-timeout-zero-",
+						"namespace":    "default",
+					},
+					"spec": map[string]interface{}{
+						"provider": map[string]interface{}{
+							"type": "vrouter-daemon",
+							"daemon": map[string]interface{}{
+								"address":        "vrouter-server.default.svc:9090",
+								"agentID":        "agent-1",
+								"timeoutSeconds": int64(0),
+							},
+						},
+					},
+				},
+			}
+			err := k8sClient.Create(ctx, target)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("timeoutSeconds"))
+		})
+
+		It("should reject a negative timeoutSeconds", func() {
+			target := &vrouterv1.VRouterTarget{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "bounds-timeout-negative-",
+					Namespace:    "default",
+				},
+				Spec: vrouterv1.VRouterTargetSpec{
+					Provider: vrouterv1.ProviderConfig{
+						Type: vrouterv1.ProviderVRouterDaemon,
+						Daemon: &vrouterv1.DaemonConfig{
+							Address:        "vrouter-server.default.svc:9090",
+							AgentID:        "agent-1",
+							TimeoutSeconds: -5,
+						},
+					},
+				},
+			}
+			err := k8sClient.Create(ctx, target)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("timeoutSeconds"))
+		})
+
+		It("should admit the minimum valid timeoutSeconds of 1", func() {
+			target := &vrouterv1.VRouterTarget{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "bounds-timeout-one-",
+					Namespace:    "default",
+				},
+				Spec: vrouterv1.VRouterTargetSpec{
+					Provider: vrouterv1.ProviderConfig{
+						Type: vrouterv1.ProviderVRouterDaemon,
+						Daemon: &vrouterv1.DaemonConfig{
+							Address:        "vrouter-server.default.svc:9090",
+							AgentID:        "agent-1",
+							TimeoutSeconds: 1,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, target)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, target)).To(Succeed())
+		})
+	})
+})


### PR DESCRIPTION
## Summary

Before this change, a VM ID of 0 or a negative number, and a config-apply timeout of 0 or a negative number of seconds, were both accepted when you created a `VRouterTarget`. The problem only showed up later, when the Proxmox API or the running code failed on the bad value. Now the schema checks these fields when the resource is created or updated, so a bad value is rejected right away with a clear error.

- `provider.proxmox.vmid` must now be at least 100. This is the smallest valid VM ID on Proxmox.
- `provider.daemon.timeoutSeconds` must now be at least 1.

## Changes

- `api/v1/proxmox_types.go`: add `+kubebuilder:validation:Minimum=100` to `ProxmoxConfig.VMID`.
- `api/v1/daemon_types.go`: add `+kubebuilder:validation:Minimum=1` to `DaemonConfig.TimeoutSeconds`.
- `config/crd/bases/vrouter.kojuro.date_vroutertargets.yaml`: regenerated via `make manifests` (gains `minimum: 100` / `minimum: 1`).
- `charts/vrouter-operator/templates/vroutertarget-crd.yaml`: hand-mirrored the same two `minimum` lines, since `helmify`/`helm` were not available in this environment to regenerate the chart directly. Please re-run the normal helmify flow next time the chart is regenerated, to keep it in sync.
- `internal/controller/vroutertarget_numeric_bounds_test.go`: new envtest cases that create `VRouterTarget` resources against a real test API server and check that it rejects `vmid` values of 0, 99, and -1, and `timeoutSeconds` values of 0 and -5, while accepting the boundary values 100 and 1.

## Test plan

- [x] Wrote the new test first and confirmed it failed before the schema change (the API server admitted the bad values).
- [x] Added the `Minimum` markers, ran `make generate` (no changes needed, pure validation markers) and `make manifests` (CRD gained the two `minimum` lines).
- [x] Confirmed the new test passes (17/17 specs in `internal/controller`).
- [x] `go build ./...` — passes.
- [x] `go vet ./...` — passes.
- [x] `make lint` — 0 issues.
- [x] `make test` (envtest, all packages) — passes.

Note on the `timeoutSeconds: 0` case: `TimeoutSeconds` is `json:"timeoutSeconds,omitempty"`, so a typed Go client silently drops an explicit `0` before it reaches the API server (the default of 60 would apply instead). That test case uses an `unstructured.Unstructured` object to put a literal `0` on the wire so the check actually exercises the new `Minimum` rule.