### PR TITLE
test(webhook): cover template syntax and reference existence

### DIFF
--- a/internal/webhook/v1/vrouterbinding_refexist_test.go
+++ b/internal/webhook/v1/vrouterbinding_refexist_test.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	vrouterv1 "github.com/tjjh89017/vrouter-operator/api/v1"
+)
+
+// These tests cover the ref-existence path of validateBinding (same namespace,
+// so cross-namespace rejection - already covered by crossns_test.go - never
+// triggers). They reuse newTestClient/metaObj/testNamespace from crossns_test.go.
+
+func TestValidateBinding_SameNamespaceTargetRef_Missing_Rejected(t *testing.T) {
+	binding := &vrouterv1.VRouterBinding{
+		ObjectMeta: metaObj("b1"),
+		Spec: vrouterv1.VRouterBindingSpec{
+			TemplateRefs: []vrouterv1.NameRef{{Name: "tmpl1"}},
+			TargetRefs:   []vrouterv1.NameRef{{Name: "missing-target"}},
+		},
+	}
+	// Seed the template so the target lookup is what fails.
+	tmpl := &vrouterv1.VRouterTemplate{ObjectMeta: metaObj("tmpl1")}
+	cl := newTestClient(t, tmpl)
+
+	err := validateBinding(context.Background(), cl, binding)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), `spec.targetRefs "missing-target" (namespace "tenant-a") not found`) {
+		t.Fatalf("error = %q, want a not-found error for the missing targetRef", err.Error())
+	}
+}
+
+func TestValidateBinding_SameNamespaceTemplateRef_Missing_Rejected(t *testing.T) {
+	binding := &vrouterv1.VRouterBinding{
+		ObjectMeta: metaObj("b1"),
+		Spec: vrouterv1.VRouterBindingSpec{
+			TemplateRefs: []vrouterv1.NameRef{{Name: "missing-template"}},
+			TargetRefs:   []vrouterv1.NameRef{{Name: "r1"}},
+		},
+	}
+	target := &vrouterv1.VRouterTarget{ObjectMeta: metaObj("r1")}
+	cl := newTestClient(t, target)
+
+	err := validateBinding(context.Background(), cl, binding)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), `spec.templateRefs[0] "missing-template" (namespace "tenant-a") not found`) {
+		t.Fatalf("error = %q, want a not-found error for the missing templateRefs entry", err.Error())
+	}
+}
+
+func TestValidateBinding_DeprecatedTemplateRef_Missing_Rejected(t *testing.T) {
+	binding := &vrouterv1.VRouterBinding{
+		ObjectMeta: metaObj("b1"),
+		Spec: vrouterv1.VRouterBindingSpec{
+			TemplateRef: &vrouterv1.NameRef{Name: "missing-template"}, //nolint:staticcheck // backward compat
+			TargetRefs:  []vrouterv1.NameRef{{Name: "r1"}},
+		},
+	}
+	target := &vrouterv1.VRouterTarget{ObjectMeta: metaObj("r1")}
+	cl := newTestClient(t, target)
+
+	err := validateBinding(context.Background(), cl, binding)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), `spec.templateRef "missing-template" (namespace "tenant-a") not found`) {
+		t.Fatalf("error = %q, want a not-found error for the missing templateRef", err.Error())
+	}
+}
+
+func TestValidateBinding_NoTemplateRefAtAll_Rejected(t *testing.T) {
+	binding := &vrouterv1.VRouterBinding{
+		ObjectMeta: metaObj("b1"),
+		Spec: vrouterv1.VRouterBindingSpec{
+			TargetRefs: []vrouterv1.NameRef{{Name: "r1"}},
+		},
+	}
+	target := &vrouterv1.VRouterTarget{ObjectMeta: metaObj("r1")}
+	cl := newTestClient(t, target)
+
+	err := validateBinding(context.Background(), cl, binding)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "at least one of spec.templateRef or spec.templateRefs must be set") {
+		t.Fatalf("error = %q, want the missing-template-ref error", err.Error())
+	}
+}
+
+func TestValidateBinding_AllRefsExist_Accepted(t *testing.T) {
+	binding := &vrouterv1.VRouterBinding{
+		ObjectMeta: metaObj("b1"),
+		Spec: vrouterv1.VRouterBindingSpec{
+			TemplateRefs: []vrouterv1.NameRef{{Name: "tmpl1"}},
+			TargetRefs:   []vrouterv1.NameRef{{Name: "r1"}, {Name: "r2"}},
+		},
+	}
+	tmpl := &vrouterv1.VRouterTemplate{ObjectMeta: metaObj("tmpl1")}
+	r1 := &vrouterv1.VRouterTarget{ObjectMeta: metaObj("r1")}
+	r2 := &vrouterv1.VRouterTarget{ObjectMeta: metaObj("r2")}
+	cl := newTestClient(t, tmpl, r1, r2)
+
+	if err := validateBinding(context.Background(), cl, binding); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+// TestVRouterBindingValidateUpdate_DeletionInProgress_SkipsRefValidation exercises
+// the webhook method (not the bare validateBinding helper) because the
+// deletion-timestamp skip lives in ValidateUpdate itself.
+func TestVRouterBindingValidateUpdate_DeletionInProgress_SkipsRefValidation(t *testing.T) {
+	now := metav1.Now()
+	binding := &vrouterv1.VRouterBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:         testNamespace,
+			Name:              "b1",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"vrouter.kojuro.date/finalizer"},
+		},
+		Spec: vrouterv1.VRouterBindingSpec{
+			TemplateRefs: []vrouterv1.NameRef{{Name: "now-missing-template"}},
+			TargetRefs:   []vrouterv1.NameRef{{Name: "now-missing-target"}},
+		},
+	}
+	// Empty client: none of the refs resolve. If the deletion skip were not
+	// honored, this would fail with a "not found" error.
+	cl := newTestClient(t)
+	validator := &VRouterBindingCustomValidator{Client: cl}
+
+	if _, err := validator.ValidateUpdate(context.Background(), binding.DeepCopy(), binding); err != nil {
+		t.Fatalf("expected deletion-in-progress update to skip ref validation, got error: %v", err)
+	}
+}
+
+// TestVRouterBindingValidateUpdate_NotDeleting_StillValidatesRefs is the
+// complementary case: when the object is not being deleted, ValidateUpdate must
+// still reject missing refs (i.e. the skip is deletion-only, not blanket).
+func TestVRouterBindingValidateUpdate_NotDeleting_StillValidatesRefs(t *testing.T) {
+	binding := &vrouterv1.VRouterBinding{
+		ObjectMeta: metaObj("b1"),
+		Spec: vrouterv1.VRouterBindingSpec{
+			TemplateRefs: []vrouterv1.NameRef{{Name: "missing-template"}},
+			TargetRefs:   []vrouterv1.NameRef{{Name: "r1"}},
+		},
+	}
+	target := &vrouterv1.VRouterTarget{ObjectMeta: metaObj("r1")}
+	cl := newTestClient(t, target)
+	validator := &VRouterBindingCustomValidator{Client: cl}
+
+	_, err := validator.ValidateUpdate(context.Background(), binding.DeepCopy(), binding)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("error = %q, want a not-found error", err.Error())
+	}
+}

--- a/internal/webhook/v1/vrouterconfig_refexist_test.go
+++ b/internal/webhook/v1/vrouterconfig_refexist_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	vrouterv1 "github.com/tjjh89017/vrouter-operator/api/v1"
+)
+
+// These tests cover the ref-existence path of validateVRouterConfig (same
+// namespace, so cross-namespace rejection - already covered by crossns_test.go -
+// never triggers). They reuse newTestClient/metaObj/testNamespace from
+// crossns_test.go.
+
+func TestValidateVRouterConfig_SameNamespaceTargetRef_Missing_Rejected(t *testing.T) {
+	cfg := &vrouterv1.VRouterConfig{
+		ObjectMeta: metaObj("c1"),
+		Spec: vrouterv1.VRouterConfigSpec{
+			TargetRef: vrouterv1.NameRef{Name: "missing-target"},
+		},
+	}
+	cl := newTestClient(t)
+
+	err := validateVRouterConfig(context.Background(), cl, cfg)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), `spec.targetRef "missing-target" not found`) {
+		t.Fatalf("error = %q, want a not-found error for the missing targetRef", err.Error())
+	}
+}
+
+func TestValidateVRouterConfig_SameNamespaceTargetRef_Exists_Accepted(t *testing.T) {
+	cfg := &vrouterv1.VRouterConfig{
+		ObjectMeta: metaObj("c1"),
+		Spec: vrouterv1.VRouterConfigSpec{
+			TargetRef: vrouterv1.NameRef{Name: "r1"},
+		},
+	}
+	target := &vrouterv1.VRouterTarget{ObjectMeta: metaObj("r1")}
+	cl := newTestClient(t, target)
+
+	if err := validateVRouterConfig(context.Background(), cl, cfg); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+// TestVRouterConfigValidateCreate_MissingTargetRef_Rejected exercises the
+// webhook method's ValidateCreate wiring (not just the bare helper).
+func TestVRouterConfigValidateCreate_MissingTargetRef_Rejected(t *testing.T) {
+	cfg := &vrouterv1.VRouterConfig{
+		ObjectMeta: metaObj("c1"),
+		Spec: vrouterv1.VRouterConfigSpec{
+			TargetRef: vrouterv1.NameRef{Name: "missing-target"},
+		},
+	}
+	cl := newTestClient(t)
+	validator := &VRouterConfigCustomValidator{Client: cl}
+
+	_, err := validator.ValidateCreate(context.Background(), cfg)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("error = %q, want a not-found error", err.Error())
+	}
+}
+
+// TestVRouterConfigValidateUpdate_DeletionInProgress_SkipsTargetRefValidation
+// exercises the webhook method (not the bare validateVRouterConfig helper)
+// because the deletion-timestamp skip lives in ValidateUpdate itself.
+func TestVRouterConfigValidateUpdate_DeletionInProgress_SkipsTargetRefValidation(t *testing.T) {
+	now := metav1.Now()
+	cfg := &vrouterv1.VRouterConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:         testNamespace,
+			Name:              "c1",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"vrouter.kojuro.date/finalizer"},
+		},
+		Spec: vrouterv1.VRouterConfigSpec{
+			TargetRef: vrouterv1.NameRef{Name: "now-missing-target"},
+		},
+	}
+	// Empty client: the targetRef does not resolve. If the deletion skip were
+	// not honored, this would fail with a "not found" error.
+	cl := newTestClient(t)
+	validator := &VRouterConfigCustomValidator{Client: cl}
+
+	if _, err := validator.ValidateUpdate(context.Background(), cfg.DeepCopy(), cfg); err != nil {
+		t.Fatalf("expected deletion-in-progress update to skip targetRef validation, got error: %v", err)
+	}
+}
+
+// TestVRouterConfigValidateUpdate_NotDeleting_StillValidatesTargetRef is the
+// complementary case: when the object is not being deleted, ValidateUpdate must
+// still reject a missing targetRef (i.e. the skip is deletion-only, not blanket).
+func TestVRouterConfigValidateUpdate_NotDeleting_StillValidatesTargetRef(t *testing.T) {
+	cfg := &vrouterv1.VRouterConfig{
+		ObjectMeta: metaObj("c1"),
+		Spec: vrouterv1.VRouterConfigSpec{
+			TargetRef: vrouterv1.NameRef{Name: "missing-target"},
+		},
+	}
+	cl := newTestClient(t)
+	validator := &VRouterConfigCustomValidator{Client: cl}
+
+	_, err := validator.ValidateUpdate(context.Background(), cfg.DeepCopy(), cfg)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("error = %q, want a not-found error", err.Error())
+	}
+}

--- a/internal/webhook/v1/vroutertemplate_syntax_test.go
+++ b/internal/webhook/v1/vroutertemplate_syntax_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	vrouterv1 "github.com/tjjh89017/vrouter-operator/api/v1"
+)
+
+// These tests exercise VRouterTemplateCustomValidator/Defaulter directly (no fake
+// client, no envtest) since validateTemplateSpec only parses Go template syntax
+// and never talks to the API server.
+
+func TestVRouterTemplateValidateCreate_ValidSyntax_Accepted(t *testing.T) {
+	tmpl := &vrouterv1.VRouterTemplate{
+		ObjectMeta: metaObj("tmpl1"),
+		Spec: vrouterv1.VRouterTemplateSpec{
+			Config:   "interface {{ .IfaceName }} { address {{ .Address }} }",
+			Commands: "commit\n{{- if .Save }}\nsave\n{{- end }}",
+		},
+	}
+	v := &VRouterTemplateCustomValidator{}
+	if _, err := v.ValidateCreate(context.Background(), tmpl); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestVRouterTemplateValidateCreate_InvalidConfigSyntax_Rejected(t *testing.T) {
+	tmpl := &vrouterv1.VRouterTemplate{
+		ObjectMeta: metaObj("tmpl-bad-config"),
+		Spec: vrouterv1.VRouterTemplateSpec{
+			// Unclosed action: missing the closing "}}".
+			Config: "interface {{ .IfaceName",
+		},
+	}
+	v := &VRouterTemplateCustomValidator{}
+	_, err := v.ValidateCreate(context.Background(), tmpl)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "spec.config: invalid template syntax") {
+		t.Fatalf("error = %q, want substring %q", err.Error(), "spec.config: invalid template syntax")
+	}
+}
+
+func TestVRouterTemplateValidateCreate_InvalidCommandsSyntax_Rejected(t *testing.T) {
+	tmpl := &vrouterv1.VRouterTemplate{
+		ObjectMeta: metaObj("tmpl-bad-commands"),
+		Spec: vrouterv1.VRouterTemplateSpec{
+			Config: "interface eth0 { }",
+			// Unclosed "if" block: no matching "{{ end }}".
+			Commands: "{{ if .Save }}\nsave",
+		},
+	}
+	v := &VRouterTemplateCustomValidator{}
+	_, err := v.ValidateCreate(context.Background(), tmpl)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "spec.commands: invalid template syntax") {
+		t.Fatalf("error = %q, want substring %q", err.Error(), "spec.commands: invalid template syntax")
+	}
+}
+
+func TestVRouterTemplateValidateUpdate_ValidSyntax_Accepted(t *testing.T) {
+	oldTmpl := &vrouterv1.VRouterTemplate{ObjectMeta: metaObj("tmpl1")}
+	newTmpl := &vrouterv1.VRouterTemplate{
+		ObjectMeta: metaObj("tmpl1"),
+		Spec: vrouterv1.VRouterTemplateSpec{
+			Config: "interface {{ .IfaceName }} { }",
+		},
+	}
+	v := &VRouterTemplateCustomValidator{}
+	if _, err := v.ValidateUpdate(context.Background(), oldTmpl, newTmpl); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestVRouterTemplateValidateUpdate_InvalidSyntax_Rejected(t *testing.T) {
+	oldTmpl := &vrouterv1.VRouterTemplate{ObjectMeta: metaObj("tmpl1")}
+	newTmpl := &vrouterv1.VRouterTemplate{
+		ObjectMeta: metaObj("tmpl1"),
+		Spec: vrouterv1.VRouterTemplateSpec{
+			Config: "interface {{ .IfaceName",
+		},
+	}
+	v := &VRouterTemplateCustomValidator{}
+	_, err := v.ValidateUpdate(context.Background(), oldTmpl, newTmpl)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "spec.config: invalid template syntax") {
+		t.Fatalf("error = %q, want substring %q", err.Error(), "spec.config: invalid template syntax")
+	}
+}
+
+func TestVRouterTemplateDefault_NoopDoesNotMutateOrError(t *testing.T) {
+	tmpl := &vrouterv1.VRouterTemplate{
+		ObjectMeta: metaObj("tmpl1"),
+		Spec: vrouterv1.VRouterTemplateSpec{
+			Config:   "interface {{ .IfaceName }} { }",
+			Commands: "commit",
+		},
+	}
+	want := tmpl.DeepCopy()
+
+	d := &VRouterTemplateCustomDefaulter{}
+	if err := d.Default(context.Background(), tmpl); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if tmpl.Spec.Config != want.Spec.Config || tmpl.Spec.Commands != want.Spec.Commands {
+		t.Fatalf("Default mutated spec: got %+v, want %+v", tmpl.Spec, want.Spec)
+	}
+}


### PR DESCRIPTION
Based on #15. Please merge #15 first. This PR is a sibling of #22 and #23; it should not include their commits.

## Summary

This PR adds tests only. It does not change any production code.

Right now, `internal/webhook/v1/vroutertemplate_webhook_test.go` is an empty scaffold, and the reference-existence checks in the binding and config webhooks have no tests. This PR fills both gaps:

- **Template syntax check** (`vroutertemplate_syntax_test.go`): tests that a virtual router template with valid Go template syntax is accepted, and a template with broken syntax (an unclosed `{{ }}` action, or an `if` block with no matching `end`) is rejected with a clear error. Covers both `ValidateCreate` and `ValidateUpdate`, plus a small check that the no-op `Default` method does not change the object.
- **Binding reference existence** (`vrouterbinding_refexist_test.go`): tests that a binding whose template and target references point to objects that exist in the same namespace is accepted, and that a binding pointing to a name that does not exist is rejected with a "not found" error. Also tests that this check is skipped while the object is being deleted, so removing the finalizer is never blocked.
- **Config target reference existence** (`vrouterconfig_refexist_test.go`): same idea for `VRouterConfig.spec.targetRef` — accepted when the target exists, rejected when it does not, and skipped during deletion.

These tests do not duplicate the cross-namespace tests in `crossns_test.go`, and do not touch the kubevirt-name, target delete-protection, or ProxmoxCluster validation work being done in other PRs.

## Test plan

- [x] `go test ./internal/webhook/v1/...` — new tests use an in-process fake client (same style as `crossns_test.go`), no envtest binaries needed for them
- [x] `KUBEBUILDER_ASSETS=... go test ./internal/webhook/...` — full package including the envtest Ginkgo suite, all green
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make lint`