### PR TITLE
ci: run tests and check generated files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,4 +36,6 @@ jobs:
         run: make manifests generate
 
       - name: Check for uncommitted changes
-        run: git diff --exit-code
+        run: |
+          git add -N .
+          git diff --exit-code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,39 @@
+name: Test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    name: Run on Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Run tests
+        run: make test
+
+  generated-files:
+    name: Check generated files are up to date
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Generate manifests and code
+        run: make manifests generate
+
+      - name: Check for uncommitted changes
+        run: git diff --exit-code


### PR DESCRIPTION
## Summary
Right now, GitHub Actions only runs the linter and builds the docker image. It never runs the unit tests, so a broken test could be merged without anyone seeing it fail.

This PR adds a new workflow, `.github/workflows/test.yml`, with two jobs:
- **test**: checks out the code, sets up Go, and runs `make test` (the unit tests, using envtest).
- **generated-files**: runs `make manifests generate` and then `git diff --exit-code`, so CI fails if the generated CRDs or deepcopy code do not match what is committed.

The workflow uses the same trigger events, checkout action, and Go setup action/version as the existing `lint.yml`, so it stays consistent with the rest of the repo.

## Test plan
- [x] Validated the YAML syntax of the new workflow file.
- [x] Ran `make test` locally on a clean checkout of `main` — it passes.
- [x] Ran `make manifests generate && git diff --exit-code` on a clean checkout of `main` — no drift, it passes.
- [x] Confirmed `docker.yml` and `lint.yml` are unchanged.