### PR TITLE
ci: run lint and test only for main pushes and PRs targeting main

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,11 @@ name: Lint
 
 on:
   push:
+    branches:
+      - main
   pull_request:
+    branches:
+      - main
 
 jobs:
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,11 @@ name: Test
 
 on:
   push:
+    branches:
+      - main
   pull_request:
+    branches:
+      - main
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

Feature-branch pushes with an open PR currently run Lint and Test twice — once via the unfiltered `push` trigger and once via `pull_request`. This scopes both workflows:

- `push`: only the `main` branch (matching the existing `docker.yml` behavior)
- `pull_request`: only PRs whose base branch is `main`

PRs targeting main still get both checks; merges to main still run them on the resulting push. Pushes to feature branches and PRs between non-main branches no longer trigger CI.