### PR TITLE
ci(e2e): KubeVirt provider e2e on GitHub Actions

### DIFF
--- a/.github/workflows/e2e-kubevirt.yml
+++ b/.github/workflows/e2e-kubevirt.yml
@@ -1,0 +1,214 @@
+name: E2E KubeVirt
+
+# Acceptance-gate workflow for issue #38: stand up the full environment on a
+# hosted runner and run the KubeVirt provider e2e suite (ginkgo label
+# "kubevirt-e2e"). It reuses the proven setup from e2e-kubevirt-probe.yml
+# (k3s + KubeVirt + a real DozenOS containerDisk guest booted on hardware KVM)
+# and adds the pieces the suite needs: a Go toolchain to run `go test`, and a
+# DozenOS containerDisk tagged for the spec.
+#
+# What this workflow deliberately does NOT do (the suite owns it, so doing it
+# here would double-work or conflict):
+#   - build/import the operator image: the suite's BeforeSuite runs
+#     `make docker-build` + LoadImageToK3sContainerd(projectImage) itself.
+#   - install CRDs / deploy the controller: the kubevirt-e2e spec's BeforeAll
+#     runs `make install` + `make deploy` itself.
+#
+# cert-manager IS installed here (the "Install cert-manager (pinned)" step),
+# early and on an un-contended node, because on this single k3s node the
+# suite's own 5m webhook-Available wait proved flaky once KubeVirt + a booting
+# VM were competing for the node. The suite is told to leave it alone via
+# CERT_MANAGER_INSTALL_SKIP=true, so its BeforeSuite skips the install and its
+# AfterSuite skips the uninstall.
+#
+# Everything below is PINNED via env. Hardware virtualization is REQUIRED: the
+# job fails fast if /dev/kvm is absent rather than silently falling back to slow
+# TCG emulation.
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+# Supersede an in-flight run when a newer commit is pushed to the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # k3s: pinned to the v1.33 stable line (channel v1.33 head, verified tag).
+  K3S_VERSION: "v1.33.13+k3s1"
+  # KubeVirt: latest stable release (operator + CR + matching virtctl).
+  KUBEVIRT_VERSION: "v1.8.4"
+  # cert-manager: installed by the workflow (not the suite). MUST match
+  # certmanagerVersion in test/utils/utils.go so a pre-existing install the
+  # suite would detect is byte-identical to what it would have installed.
+  CERT_MANAGER_VERSION: "v1.16.3"
+  # DozenOS guest image: latest nightly by default. Point this at a specific
+  # release's version.json (…/releases/download/<tag>/version.json) to pin.
+  DOZENOS_VERSION_JSON_URL: "https://github.com/dozenos/dozenos-nightly-build/releases/latest/download/version.json"
+  # Guest containerDisk tag the kubevirt-e2e spec expects; imported into the k3s
+  # node's containerd and surfaced to the suite via E2E_ROUTER_CONTAINERDISK.
+  E2E_ROUTER_CONTAINERDISK: "dozenos-e2e:latest"
+
+jobs:
+  e2e-kubevirt:
+    name: KubeVirt provider e2e
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Enable KVM access via udev rule
+        run: |
+          set -euo pipefail
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Require /dev/kvm (fail fast if absent)
+        run: |
+          set -euo pipefail
+          if [ -e /dev/kvm ]; then
+            echo "KVM_PRESENT=true"
+            ls -l /dev/kvm
+          else
+            echo "::error::/dev/kvm not present on this runner — hardware virtualization is required; failing instead of falling back to TCG emulation." >&2
+            exit 1
+          fi
+
+      - name: Raise inotify limits (KubeVirt-in-CI failure mode)
+        run: |
+          set -euo pipefail
+          sudo sysctl fs.inotify.max_user_watches=1048576
+          sudo sysctl fs.inotify.max_user_instances=8192
+
+      - name: Install k3s (pinned)
+        run: |
+          set -euo pipefail
+          curl -sfL https://get.k3s.io \
+            | INSTALL_K3S_VERSION="${K3S_VERSION}" sh -s - --write-kubeconfig-mode 644
+          echo "KUBECONFIG=/etc/rancher/k3s/k3s.yaml" >> "$GITHUB_ENV"
+          export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+          kubectl wait --for=condition=Ready node --all --timeout=120s
+          kubectl get nodes -o wide
+
+      - name: Install cert-manager (pinned)
+        run: |
+          set -euo pipefail
+          # Installed here, before KubeVirt + the booting VM contend for this
+          # single node, so cert-manager comes up on an un-contended node. The
+          # suite is told to skip its own install/uninstall via
+          # CERT_MANAGER_INSTALL_SKIP=true on the suite step below.
+          kubectl apply -f "https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml"
+          # rollout status blocks until each Deployment finishes; wait on all
+          # three so the webhook is genuinely serving before the suite runs.
+          kubectl -n cert-manager rollout status deployment/cert-manager --timeout=8m
+          kubectl -n cert-manager rollout status deployment/cert-manager-webhook --timeout=8m
+          kubectl -n cert-manager rollout status deployment/cert-manager-cainjector --timeout=8m
+          kubectl -n cert-manager get pods -o wide
+
+      - name: Install KubeVirt (pinned) and virtctl
+        run: |
+          set -euo pipefail
+          kubectl apply -f "https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-operator.yaml"
+          # virt-operator Available guarantees the KubeVirt CRD is established
+          # before we apply the CR below.
+          kubectl -n kubevirt rollout status deployment/virt-operator --timeout=300s
+          kubectl apply -f "https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-cr.yaml"
+          # /dev/kvm is guaranteed present (checked earlier), so KubeVirt uses
+          # hardware acceleration — no useEmulation patch.
+          kubectl -n kubevirt wait kubevirt/kubevirt --for=condition=Available --timeout=10m
+
+          curl -sfL -o virtctl \
+            "https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/virtctl-${KUBEVIRT_VERSION}-linux-amd64"
+          chmod +x virtctl
+          sudo mv virtctl /usr/local/bin/virtctl
+          virtctl version || true
+
+      - name: Resolve, download and verify DozenOS KVM qcow2; build & import guest containerDisk
+        run: |
+          set -euo pipefail
+          work="${RUNNER_TEMP}/dozenos"
+          mkdir -p "$work"
+
+          curl -sfL "${DOZENOS_VERSION_JSON_URL}" -o "$work/version.json"
+
+          # version.json (verified structure): top-level .version + .artifacts[],
+          # each artifact carries .flavor/.install_type/.format/.name/.sha256/.url.
+          sel='.artifacts[] | select(.flavor=="kvm" and .format=="qcow2" and .install_type=="fresh-install")'
+          version="$(jq -r '.version' "$work/version.json")"
+          name="$(jq -r "$sel | .name"   "$work/version.json")"
+          url="$(jq -r "$sel | .url"     "$work/version.json")"
+          sha="$(jq -r "$sel | .sha256"  "$work/version.json")"
+
+          echo "DozenOS version:   ${version}"
+          echo "Artifact name:     ${name}"
+          echo "Artifact url:      ${url}"
+          echo "Expected sha256:   ${sha}"
+
+          if [ -z "$url" ] || [ "$url" = "null" ]; then
+            echo "No kvm/qcow2 fresh-install artifact found in version.json" >&2
+            exit 1
+          fi
+
+          curl -sfL "$url" -o "$work/disk.qcow2"
+          echo "${sha}  ${work}/disk.qcow2" | sha256sum -c -
+
+          # containerDisk: FROM scratch with the qcow2 under /disk/ (per KubeVirt
+          # containerDisk contract). CDI is intentionally NOT used.
+          cat > "$work/Dockerfile" <<'DOCKERFILE'
+          FROM scratch
+          ADD --chown=107:107 disk.qcow2 /disk/
+          DOCKERFILE
+
+          docker build -t "${E2E_ROUTER_CONTAINERDISK}" "$work"
+          # Import into the k3s node's containerd (k3s ctr defaults to the
+          # k8s.io namespace used by the kubelet). Mirrors the suite's
+          # LoadImageToK3sContainerd path for the operator image.
+          docker save "${E2E_ROUTER_CONTAINERDISK}" | sudo k3s ctr images import -
+          sudo k3s ctr images ls | grep -i "dozenos-e2e" \
+            || { echo "guest containerDisk image missing from containerd" >&2; exit 1; }
+
+      - name: Run KubeVirt provider e2e suite
+        env:
+          # cert-manager is already installed by the workflow step above, so
+          # tell the suite to skip both its BeforeSuite install and (crucially)
+          # its AfterSuite uninstall — the latter otherwise hangs on teardown.
+          CERT_MANAGER_INSTALL_SKIP: "true"
+        run: |
+          set -euo pipefail
+          # The suite's BeforeSuite builds + imports the operator image; the
+          # kubevirt-e2e spec's BeforeAll runs `make install` / `make deploy`.
+          # cert-manager is pre-installed by the workflow and left untouched by
+          # the suite (CERT_MANAGER_INSTALL_SKIP above). We only focus the
+          # labeled spec on the pre-provisioned k3s cluster and hand it the
+          # guest containerDisk tag via E2E_ROUTER_CONTAINERDISK (job level).
+          make test-e2e E2E_CLUSTER=k3s GINKGO_LABEL_FILTER=kubevirt-e2e
+
+      - name: Collect diagnostics on failure
+        if: failure()
+        run: |
+          set +e
+          echo "===== DIAGNOSTICS ====="
+          kubectl get vm,vmi -A -o wide
+          kubectl get pods -A -o wide
+          kubectl -n kubevirt get kubevirt kubevirt -o yaml
+          echo "----- vrouter CRs -----"
+          kubectl get vrouterconfigs,vroutertargets -A -o wide
+          echo "----- VM/VMI describe (default ns) -----"
+          kubectl -n default describe vm 2>/dev/null | tail -n 80
+          kubectl -n default describe vmi 2>/dev/null | tail -n 80
+          LAUNCHER="$(kubectl -n default get pod -l kubevirt.io=virt-launcher -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)"
+          [ -n "$LAUNCHER" ] && kubectl -n default logs "$LAUNCHER" --all-containers --tail=100
+          echo "----- controller-manager logs -----"
+          kubectl -n vrouter-operator-system get pods -o wide
+          kubectl -n vrouter-operator-system logs deployment/vrouter-operator-controller-manager --all-containers --tail=200

--- a/.github/workflows/e2e-kubevirt.yml
+++ b/.github/workflows/e2e-kubevirt.yml
@@ -2,10 +2,9 @@ name: E2E KubeVirt
 
 # Acceptance-gate workflow for issue #38: stand up the full environment on a
 # hosted runner and run the KubeVirt provider e2e suite (ginkgo label
-# "kubevirt-e2e"). It reuses the proven setup from e2e-kubevirt-probe.yml
-# (k3s + KubeVirt + a real DozenOS containerDisk guest booted on hardware KVM)
-# and adds the pieces the suite needs: a Go toolchain to run `go test`, and a
-# DozenOS containerDisk tagged for the spec.
+# "kubevirt-e2e"). It stands up k3s + KubeVirt + a real DozenOS containerDisk
+# guest booted on hardware KVM, plus the pieces the suite needs: a Go toolchain
+# to run `go test`, and a DozenOS containerDisk tagged for the spec.
 #
 # What this workflow deliberately does NOT do (the suite owns it, so doing it
 # here would double-work or conflict):

--- a/Makefile
+++ b/Makefile
@@ -118,8 +118,29 @@ test: manifests generate fmt vet setup-envtest ## Run tests.
 # - CERT_MANAGER_INSTALL_SKIP=true
 KIND_CLUSTER ?= vrouter-operator-test-e2e
 
+# E2E_CLUSTER selects the cluster flavor the e2e suite targets. The default
+# "kind" creates and deletes a throwaway Kind cluster locally. Set E2E_CLUSTER=k3s
+# to run against a pre-provisioned single-node k3s cluster (e.g. the KubeVirt CI
+# job, which stands up k3s + KubeVirt and sets KUBECONFIG itself): setup/cleanup
+# become no-ops that leave the external cluster intact, and the manager image is
+# imported into the node's containerd instead of `kind load`.
+E2E_CLUSTER ?= kind
+
+# GINKGO_LABEL_FILTER optionally focuses the e2e run on specs carrying a given
+# ginkgo label (e.g. GINKGO_LABEL_FILTER=kubevirt-e2e for the k3s KubeVirt CI
+# job, which stands up real KubeVirt + KVM and runs only that labeled spec).
+# Empty by default: the full suite runs, preserving existing behavior.
+GINKGO_LABEL_FILTER ?=
+
+# E2E_TIMEOUT bounds the whole `go test` binary. The default go test timeout is
+# 10m, which the real KubeVirt suite (VM boot + per-spec multi-minute Eventually
+# waits) blows through; the k3s CI job's own budget is 40m, so allow well over
+# the default here. Harmless to the fast Kind path, which finishes long before.
+E2E_TIMEOUT ?= 35m
+
 .PHONY: setup-test-e2e
-setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
+setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist (skipped when E2E_CLUSTER!=kind)
+ifeq ($(E2E_CLUSTER),kind)
 	@command -v $(KIND) >/dev/null 2>&1 || { \
 		echo "Kind is not installed. Please install Kind manually."; \
 		exit 1; \
@@ -131,15 +152,26 @@ setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
 			echo "Creating Kind cluster '$(KIND_CLUSTER)'..."; \
 			$(KIND) create cluster --name $(KIND_CLUSTER) ;; \
 	esac
+else
+	@echo "E2E_CLUSTER=$(E2E_CLUSTER): using pre-provisioned cluster, skipping Kind creation."
+	@$(KUBECTL) cluster-info >/dev/null 2>&1 || { \
+		echo "No reachable cluster: set KUBECONFIG to the pre-provisioned $(E2E_CLUSTER) cluster."; \
+		exit 1; \
+	}
+endif
 
 .PHONY: test-e2e
-test-e2e: setup-test-e2e manifests generate fmt vet ## Run the e2e tests. Expected an isolated environment using Kind.
-	KIND_CLUSTER=$(KIND_CLUSTER) go test ./test/e2e/ -v -ginkgo.v
-	$(MAKE) cleanup-test-e2e
+test-e2e: setup-test-e2e manifests generate fmt vet ## Run the e2e tests. Expected an isolated Kind environment, or a pre-provisioned cluster via E2E_CLUSTER.
+	KIND_CLUSTER=$(KIND_CLUSTER) E2E_CLUSTER=$(E2E_CLUSTER) go test ./test/e2e/ -v -ginkgo.v -timeout $(E2E_TIMEOUT) $(if $(GINKGO_LABEL_FILTER),-ginkgo.label-filter=$(GINKGO_LABEL_FILTER),)
+	$(MAKE) cleanup-test-e2e E2E_CLUSTER=$(E2E_CLUSTER)
 
 .PHONY: cleanup-test-e2e
-cleanup-test-e2e: ## Tear down the Kind cluster used for e2e tests
+cleanup-test-e2e: ## Tear down the Kind cluster used for e2e tests (skipped when E2E_CLUSTER!=kind)
+ifeq ($(E2E_CLUSTER),kind)
 	@$(KIND) delete cluster --name $(KIND_CLUSTER)
+else
+	@echo "E2E_CLUSTER=$(E2E_CLUSTER): pre-provisioned cluster left intact."
+endif
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -667,10 +667,14 @@ onChange():
          generation check in step 6 before it ever runs — deadlock the
          config exactly like the "exec result lost" case, immune even to a
          spec update.
-       → exitCode == 0 → clear execPID, set phase=Applied, condition Applied=True
-         (stamped with the generation this exec was dispatched for), return nil
-       → exitCode != 0 → clear execPID, set phase=Failed, condition Applied=False
-         (stamped with the generation this exec was dispatched for), return nil
+       → exitCode == 0 and no failure marker in the apply output → clear execPID,
+         set phase=Applied, condition Applied=True (stamped with the generation
+         this exec was dispatched for), return nil
+       → exitCode != 0, OR a failure marker (Set failed / Commit failed /
+         Delete failed) is present in the apply output even with exitCode == 0
+         (a set-time validation failure still lets `commit` exit 0, see §7.4) →
+         clear execPID, set phase=Failed, condition Applied=False (stamped with
+         the generation this exec was dispatched for), return nil
 
   5. Check reboot: force re-apply only if target.status.lastRebootTime is newer
      than the last reboot this config has already dispatched an attempt for.
@@ -799,6 +803,7 @@ save
 - `commands`: a single pre-joined block of `set` commands (already newline-joined by BindingController from one or more templates, or supplied directly on a hand-authored VRouterConfig) executed in configure mode — not a list iterated by the script template itself
 - `commit` is always appended; `save` is conditional (default: true), controlled by `spec.save`
 - The script is written to a fixed path `/tmp/vrouter-apply.sh` (overwritten each time) then executed
+- **The guest exit code is not the sole success signal.** A `set` command that fails at set-time (e.g. an invalid interface address) prints an error to the output, but because the preceding `load` already left a committable diff, `commit` still exits 0 — so the exit code alone can mask the failure. The operator therefore also scans the combined apply output (stdout+stderr) for a curated list of router config validator failure markers (`Set failed`, `Commit failed`, `Delete failed`, matched case-insensitively) and reports `phase=Failed` on a match even when the exit code is 0. `set -e` in the apply script is not an option: the vyatta config-mode `set`/`load` functions return non-zero even on success, so it would abort valid configs.
 
 ### 7.5 QGA Script Execution Flow
 

--- a/internal/controller/vrouterconfig_controller.go
+++ b/internal/controller/vrouterconfig_controller.go
@@ -38,6 +38,7 @@ import (
 
 	vrouterv1 "github.com/tjjh89017/vrouter-operator/api/v1"
 	"github.com/tjjh89017/vrouter-operator/internal/provider"
+	"github.com/tjjh89017/vrouter-operator/internal/provider/qga"
 	providertypes "github.com/tjjh89017/vrouter-operator/internal/provider/types"
 )
 
@@ -375,7 +376,13 @@ func (r *VRouterConfigReconciler) pollExecStatus(ctx context.Context, cfg *vrout
 	// cfg.Generation may already have moved on to a generation that was
 	// never actually applied; the exec that just finished only speaks for
 	// the generation it was dispatched for.
-	if status.ExitCode == 0 {
+	// The guest exit code is not the sole success signal. A set-time
+	// validation failure prints an error to the output but still lets `commit`
+	// exit 0 (the preceding `load` left a committable diff), so the exit code
+	// can mask the failure. Also scan the combined output for a curated
+	// failure marker and treat a match as a failure even when ExitCode == 0.
+	marker, markerFailed := qga.ApplyOutputIndicatesFailure(status.Stdout + "\n" + status.Stderr)
+	if status.ExitCode == 0 && !markerFailed {
 		now := metav1.Now()
 		cfg.Status.Phase = vrouterv1.PhaseApplied
 		cfg.Status.LastAppliedTime = &now
@@ -389,8 +396,13 @@ func (r *VRouterConfigReconciler) pollExecStatus(ctx context.Context, cfg *vrout
 		})
 		log.Info("config applied successfully")
 	} else {
+		if markerFailed && status.ExitCode == 0 {
+			cfg.Status.Message = fmt.Sprintf("apply reported failure (%s) despite exitCode=0; stderr=%s",
+				marker, strings.TrimSpace(status.Stderr))
+		} else {
+			cfg.Status.Message = fmt.Sprintf("exitCode=%d stderr=%s", status.ExitCode, strings.TrimSpace(status.Stderr))
+		}
 		cfg.Status.Phase = vrouterv1.PhaseFailed
-		cfg.Status.Message = fmt.Sprintf("exitCode=%d stderr=%s", status.ExitCode, strings.TrimSpace(status.Stderr))
 		meta.SetStatusCondition(&cfg.Status.Conditions, metav1.Condition{
 			Type:               vrouterv1.ConditionApplied,
 			Status:             metav1.ConditionFalse,
@@ -398,7 +410,7 @@ func (r *VRouterConfigReconciler) pollExecStatus(ctx context.Context, cfg *vrout
 			Message:            cfg.Status.Message,
 			ObservedGeneration: cfg.Status.ObservedGeneration,
 		})
-		log.Info("config apply failed", "exitCode", status.ExitCode, "stderr", status.Stderr)
+		log.Info("config apply failed", "exitCode", status.ExitCode, "marker", marker, "stderr", status.Stderr)
 	}
 	return ctrl.Result{}, r.Status().Patch(ctx, cfg, patch)
 }

--- a/internal/controller/vrouterconfig_output_marker_test.go
+++ b/internal/controller/vrouterconfig_output_marker_test.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+
+	vrouterv1 "github.com/tjjh89017/vrouter-operator/api/v1"
+	providertypes "github.com/tjjh89017/vrouter-operator/internal/provider/types"
+)
+
+// fakeOutputProvider is a types.Provider stub whose GetExecStatus reports the
+// exec as exited with a fixed exit code and a fixed stdout/stderr, so tests can
+// drive the output-marker scanning path in pollExecStatus.
+type fakeOutputProvider struct {
+	exitCode int
+	stdout   string
+	stderr   string
+}
+
+func (fakeOutputProvider) IsVMRunning(_ context.Context) (bool, error) { return true, nil }
+func (fakeOutputProvider) CheckReady(_ context.Context) error          { return nil }
+func (fakeOutputProvider) ExecScript(_ context.Context, _, _ string, _ bool) (int64, error) {
+	return 0, nil
+}
+func (p fakeOutputProvider) GetExecStatus(_ context.Context, _ int64) (*providertypes.ExecStatus, error) {
+	return &providertypes.ExecStatus{Exited: true, ExitCode: p.exitCode, Stdout: p.stdout, Stderr: p.stderr}, nil
+}
+
+// TestPollExecStatus_ZeroExitWithFailureMarker_SetsAppliedFalse is the
+// regression test for the exit-code masking bug: a set-time validation failure
+// prints "Set failed" to the apply output but `commit` still exits 0 (the
+// preceding `load` left a committable diff). The exit code lies, so the
+// operator must also scan the output for a failure marker and report Failed —
+// otherwise it would wrongly report Applied.
+func TestPollExecStatus_ZeroExitWithFailureMarker_SetsAppliedFalse(t *testing.T) {
+	cfg := &vrouterv1.VRouterConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "c1", Namespace: "default", Generation: 1},
+		Spec: vrouterv1.VRouterConfigSpec{
+			TargetRef: vrouterv1.NameRef{Name: "r1"},
+			Config:    "set interfaces ethernet eth0 address 'not-an-ip'",
+		},
+		Status: vrouterv1.VRouterConfigStatus{
+			Phase:              vrouterv1.PhaseApplying,
+			ExecPID:            42,
+			ObservedGeneration: 1,
+		},
+	}
+
+	r, cl := newFakeReconciler(t, cfg)
+
+	prov := fakeOutputProvider{
+		exitCode: 0,
+		stdout: "Load complete. Use 'commit' to make changes effective.\n" +
+			"  Error: not-an-ip is not a valid network interface address\n" +
+			"  Invalid value\n  Value validation failed\n  Set failed",
+	}
+
+	if _, err := r.pollExecStatus(context.Background(), cfg, prov); err != nil {
+		t.Fatalf("pollExecStatus returned error: %v", err)
+	}
+
+	if cfg.Status.Phase != vrouterv1.PhaseFailed {
+		t.Errorf("status.phase = %q, want %q (marker in output must fail the apply despite exitCode=0)",
+			cfg.Status.Phase, vrouterv1.PhaseFailed)
+	}
+
+	cond := findAppliedCondition(cfg.Status.Conditions)
+	if cond == nil {
+		t.Fatalf("expected an Applied condition to be set")
+	}
+	if cond.Status != metav1.ConditionFalse {
+		t.Errorf("Applied condition status = %q, want %q", cond.Status, metav1.ConditionFalse)
+	}
+	if cond.Reason != "ConfigFailed" {
+		t.Errorf("Applied condition reason = %q, want %q", cond.Reason, "ConfigFailed")
+	}
+
+	var got vrouterv1.VRouterConfig
+	if err := cl.Get(context.Background(), k8stypes.NamespacedName{Name: "c1", Namespace: "default"}, &got); err != nil {
+		t.Fatalf("get updated config: %v", err)
+	}
+	if got.Status.Phase != vrouterv1.PhaseFailed {
+		t.Errorf("persisted status.phase = %q, want %q", got.Status.Phase, vrouterv1.PhaseFailed)
+	}
+	if persistedCond := findAppliedCondition(got.Status.Conditions); persistedCond == nil ||
+		persistedCond.Status != metav1.ConditionFalse {
+		t.Errorf("persisted Applied condition = %+v, want status False", persistedCond)
+	}
+}
+
+// TestPollExecStatus_ZeroExitCleanOutput_StaysApplied guards the happy path:
+// a clean exit-0 apply whose output contains no failure marker must still
+// reach Applied — the marker scan must not produce false positives.
+func TestPollExecStatus_ZeroExitCleanOutput_StaysApplied(t *testing.T) {
+	cfg := &vrouterv1.VRouterConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "c1", Namespace: "default", Generation: 1},
+		Spec: vrouterv1.VRouterConfigSpec{
+			TargetRef: vrouterv1.NameRef{Name: "r1"},
+			Config:    "set system host-name test",
+		},
+		Status: vrouterv1.VRouterConfigStatus{
+			Phase:              vrouterv1.PhaseApplying,
+			ExecPID:            42,
+			ObservedGeneration: 1,
+		},
+	}
+
+	r, _ := newFakeReconciler(t, cfg)
+
+	prov := fakeOutputProvider{
+		exitCode: 0,
+		stdout:   "Load complete. Use 'commit' to make changes effective.",
+	}
+
+	if _, err := r.pollExecStatus(context.Background(), cfg, prov); err != nil {
+		t.Fatalf("pollExecStatus returned error: %v", err)
+	}
+
+	if cfg.Status.Phase != vrouterv1.PhaseApplied {
+		t.Errorf("status.phase = %q, want %q", cfg.Status.Phase, vrouterv1.PhaseApplied)
+	}
+	cond := findAppliedCondition(cfg.Status.Conditions)
+	if cond == nil || cond.Status != metav1.ConditionTrue {
+		t.Errorf("Applied condition = %+v, want status True", cond)
+	}
+}

--- a/internal/provider/flavor/flavor.go
+++ b/internal/provider/flavor/flavor.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package flavor abstracts guest-OS-flavor-specific behavior so that provider
+// readiness/apply logic does not hardcode assumptions that differ between guest
+// images. A flavor is identified by the /etc/os-release ID field; new guest
+// OSes slot in as additional Flavor implementations registered in byID.
+package flavor
+
+import "fmt"
+
+// Flavor answers guest-OS-flavor-specific questions. For now that is just the
+// router systemd unit name; future flavor-specific behavior extends this
+// interface (or is answered by the concrete implementations).
+type Flavor interface {
+	// RouterServiceUnit returns the systemd unit name of the router service
+	// whose completion signals the guest is ready to accept config.
+	RouterServiceUnit() string
+}
+
+// vyos is the flavor for VyOS guests (/etc/os-release ID=vyos).
+type vyos struct{}
+
+func (vyos) RouterServiceUnit() string { return "vyos-router.service" }
+
+// dozenos is the flavor for DozenOS guests (/etc/os-release ID=dozenos).
+type dozenos struct{}
+
+func (dozenos) RouterServiceUnit() string { return "dozenos-router.service" }
+
+// byID maps an /etc/os-release ID to its Flavor. Register new flavors here.
+var byID = map[string]Flavor{
+	"vyos":    vyos{},
+	"dozenos": dozenos{},
+}
+
+// ByID resolves the Flavor for an /etc/os-release ID. It returns an error for
+// an unknown ID rather than defaulting, so an unrecognized guest surfaces
+// loudly instead of silently using the wrong unit name.
+func ByID(id string) (Flavor, error) {
+	f, ok := byID[id]
+	if !ok {
+		return nil, fmt.Errorf("unknown guest OS flavor ID %q", id)
+	}
+	return f, nil
+}

--- a/internal/provider/flavor/flavor_test.go
+++ b/internal/provider/flavor/flavor_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flavor
+
+import "testing"
+
+// TestByID_KnownFlavors verifies that each registered /etc/os-release ID
+// resolves to a Flavor with the expected router systemd unit name and no error.
+func TestByID_KnownFlavors(t *testing.T) {
+	tests := []struct {
+		name     string
+		id       string
+		wantUnit string
+	}{
+		{
+			name:     "vyos ID resolves to vyos-router.service",
+			id:       "vyos",
+			wantUnit: "vyos-router.service",
+		},
+		{
+			name:     "dozenos ID resolves to dozenos-router.service",
+			id:       "dozenos",
+			wantUnit: "dozenos-router.service",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Act
+			fl, err := ByID(tt.id)
+
+			// Assert
+			if err != nil {
+				t.Fatalf("ByID(%q) returned unexpected error: %v", tt.id, err)
+			}
+			if fl == nil {
+				t.Fatalf("ByID(%q) returned nil flavor with no error", tt.id)
+			}
+			if got := fl.RouterServiceUnit(); got != tt.wantUnit {
+				t.Fatalf("ByID(%q).RouterServiceUnit() = %q, want %q", tt.id, got, tt.wantUnit)
+			}
+		})
+	}
+}
+
+// TestByID_UnknownFlavors verifies that an unrecognized /etc/os-release ID
+// surfaces an error and a nil Flavor rather than silently defaulting.
+func TestByID_UnknownFlavors(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+	}{
+		{name: "unrelated distro ID", id: "ubuntu"},
+		{name: "empty ID", id: ""},
+		{name: "arbitrary unknown ID", id: "totally-unknown-os"},
+		{name: "case mismatch is not matched", id: "VyOS"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Act
+			fl, err := ByID(tt.id)
+
+			// Assert
+			if err == nil {
+				t.Fatalf("ByID(%q) expected an error for unknown ID, got nil", tt.id)
+			}
+			if fl != nil {
+				t.Fatalf("ByID(%q) expected nil flavor on error, got %#v", tt.id, fl)
+			}
+		})
+	}
+}

--- a/internal/provider/kubevirt/provider.go
+++ b/internal/provider/kubevirt/provider.go
@@ -34,6 +34,7 @@ import (
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/tjjh89017/vrouter-operator/internal/provider/flavor"
 	"github.com/tjjh89017/vrouter-operator/internal/provider/qga"
 	providertypes "github.com/tjjh89017/vrouter-operator/internal/provider/types"
 )
@@ -78,18 +79,53 @@ func (p *Provider) IsVMRunning(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
-// CheckReady verifies QGA responds to ping, then polls the SubState of
-// vyos-router.service until it reports "exited" — the service is a oneshot
-// unit that runs to completion, so readiness is "has finished", not
-// "is-active/running".
+// CheckReady verifies QGA responds to ping, detects the guest OS flavor, then
+// polls the SubState of that flavor's router service until it reports "exited"
+// — the service is a oneshot unit that runs to completion, so readiness is
+// "has finished", not "is-active/running".
 func (p *Provider) CheckReady(ctx context.Context) error {
 	if _, err := p.runQGA(ctx, qga.CmdPing); err != nil {
 		return fmt.Errorf("QGA not responding: %w", err)
 	}
 
-	resp, err := p.runQGA(ctx, fmt.Sprintf(qga.CmdExecServiceSubState, qga.VyOSService))
+	fl, err := p.detectFlavor(ctx)
+	if err != nil {
+		return fmt.Errorf("detect guest OS flavor: %w", err)
+	}
+	unit := fl.RouterServiceUnit()
+
+	out, err := p.runGuestExecCapture(ctx, fmt.Sprintf(qga.CmdExecServiceSubState, unit))
 	if err != nil {
 		return fmt.Errorf("service substate check: %w", err)
+	}
+	substate := strings.TrimSpace(out)
+	if substate != "exited" {
+		return fmt.Errorf("%s not ready (substate=%s)", unit, substate)
+	}
+	return nil
+}
+
+// detectFlavor reads /etc/os-release from the guest via QGA and resolves the
+// guest OS flavor from its ID field. An unmappable ID is surfaced as an error.
+func (p *Provider) detectFlavor(ctx context.Context) (flavor.Flavor, error) {
+	out, err := p.runGuestExecCapture(ctx, qga.CmdExecOSRelease)
+	if err != nil {
+		return nil, fmt.Errorf("read /etc/os-release: %w", err)
+	}
+	id := parseOSReleaseID(out)
+	if id == "" {
+		return nil, fmt.Errorf("no ID field in /etc/os-release")
+	}
+	return flavor.ByID(id)
+}
+
+// runGuestExecCapture runs a guest-exec QGA command, polls guest-exec-status
+// until the process exits, and returns its base64-decoded stdout. A non-zero
+// exit code is reported as an error.
+func (p *Provider) runGuestExecCapture(ctx context.Context, execCmd string) (string, error) {
+	resp, err := p.runQGA(ctx, execCmd)
+	if err != nil {
+		return "", err
 	}
 	var execResult struct {
 		Return struct {
@@ -97,14 +133,14 @@ func (p *Provider) CheckReady(ctx context.Context) error {
 		} `json:"return"`
 	}
 	if err := json.Unmarshal([]byte(resp), &execResult); err != nil {
-		return fmt.Errorf("service substate check parse: %w", err)
+		return "", fmt.Errorf("guest-exec parse: %w", err)
 	}
 
-	// Poll until systemctl show exits (completes quickly in practice).
+	// Poll until the process exits (completes quickly in practice).
 	for {
 		statusResp, err := p.runQGA(ctx, fmt.Sprintf(qga.CmdExecStatus, execResult.Return.PID))
 		if err != nil {
-			return fmt.Errorf("service substate status: %w", err)
+			return "", fmt.Errorf("guest-exec-status: %w", err)
 		}
 		var statusResult struct {
 			Return struct {
@@ -114,25 +150,35 @@ func (p *Provider) CheckReady(ctx context.Context) error {
 			} `json:"return"`
 		}
 		if err := json.Unmarshal([]byte(statusResp), &statusResult); err != nil {
-			return fmt.Errorf("service substate status parse: %w", err)
+			return "", fmt.Errorf("guest-exec-status parse: %w", err)
 		}
 		if statusResult.Return.Exited {
 			if statusResult.Return.ExitCode != 0 {
-				return fmt.Errorf("systemctl show failed (exitCode=%d)", statusResult.Return.ExitCode)
+				return "", fmt.Errorf("guest-exec exited non-zero (exitCode=%d)", statusResult.Return.ExitCode)
 			}
-			substate, _ := decodeBase64OrEmpty(statusResult.Return.OutData)
-			substate = strings.TrimSpace(substate)
-			if substate != "exited" {
-				return fmt.Errorf("%s not ready (substate=%s)", qga.VyOSService, substate)
-			}
-			return nil
+			return decodeBase64OrEmpty(statusResult.Return.OutData)
 		}
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return "", ctx.Err()
 		case <-time.After(500 * time.Millisecond):
 		}
 	}
+}
+
+// parseOSReleaseID extracts the ID field from /etc/os-release content. Values
+// may be quoted; surrounding quotes and whitespace are stripped. It matches
+// only the exact "ID=" key, never "ID_LIKE=".
+func parseOSReleaseID(content string) string {
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "ID=") {
+			continue
+		}
+		val := strings.TrimSpace(strings.TrimPrefix(line, "ID="))
+		return strings.Trim(val, `"'`)
+	}
+	return ""
 }
 
 // ExecScript renders the vbash apply script, writes it to the router via QGA,

--- a/internal/provider/kubevirt/provider_internal_test.go
+++ b/internal/provider/kubevirt/provider_internal_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubevirt
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestParseOSReleaseID verifies parseOSReleaseID extracts the ID field from
+// /etc/os-release text: it strips surrounding quotes and whitespace, matches
+// only the exact "ID=" key (never "ID_LIKE="), and returns "" when absent.
+func TestParseOSReleaseID(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "unquoted value",
+			content: "ID=dozenos",
+			want:    "dozenos",
+		},
+		{
+			name:    "double-quoted value",
+			content: `ID="vyos"`,
+			want:    "vyos",
+		},
+		{
+			name:    "single-quoted value",
+			content: "ID='vyos'",
+			want:    "vyos",
+		},
+		{
+			name:    "ID_LIKE present but no ID must not match",
+			content: "ID_LIKE=debian",
+			want:    "",
+		},
+		{
+			name: "realistic os-release with ID_LIKE before and after ID",
+			content: strings.Join([]string{
+				`NAME="VyOS"`,
+				`PRETTY_NAME="VyOS 1.4"`,
+				`ID_LIKE=debian`,
+				`ID=vyos`,
+				`VERSION_ID="1.4"`,
+				`ID_LIKE=debian`,
+			}, "\n"),
+			want: "vyos",
+		},
+		{
+			name:    "CRLF line endings strip trailing carriage return",
+			content: "NAME=\"DozenOS\"\r\nID=dozenos\r\nVERSION_ID=\"1.0\"\r\n",
+			want:    "dozenos",
+		},
+		{
+			name:    "leading and trailing whitespace around the line",
+			content: "   \t ID=vyos \t  ",
+			want:    "vyos",
+		},
+		{
+			name: "missing ID entirely returns empty",
+			content: strings.Join([]string{
+				`NAME="SomeOS"`,
+				`ID_LIKE=debian`,
+				`VERSION_ID="9"`,
+			}, "\n"),
+			want: "",
+		},
+		{
+			name:    "empty content returns empty",
+			content: "",
+			want:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Act
+			got := parseOSReleaseID(tt.content)
+
+			// Assert
+			if got != tt.want {
+				t.Fatalf("parseOSReleaseID(%q) = %q, want %q", tt.content, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/provider/qga/constants.go
+++ b/internal/provider/qga/constants.go
@@ -33,6 +33,9 @@ const (
 	CmdExecServiceSubState = `{"execute":"guest-exec","arguments":{"path":"/usr/bin/systemctl","arg":["show","-p","SubState","--value",%q],"capture-output":true}}`
 	// CmdExecScript runs /bin/vbash with the given script path, capturing output.
 	CmdExecScript = `{"execute":"guest-exec","arguments":{"path":"/bin/vbash","arg":[%q],"capture-output":true}}`
+	// CmdExecOSRelease reads /etc/os-release from the guest, capturing output.
+	// Its ID= field selects the guest OS flavor (see internal/provider/flavor).
+	CmdExecOSRelease = `{"execute":"guest-exec","arguments":{"path":"/bin/cat","arg":["/etc/os-release"],"capture-output":true}}`
 
 	CmdExecStatus = `{"execute":"guest-exec-status","arguments":{"pid":%d}}`
 )

--- a/internal/provider/qga/failure_marker.go
+++ b/internal/provider/qga/failure_marker.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package qga
+
+import "strings"
+
+// applyFailureMarkers is a small, curated list of failure markers emitted by
+// the router config validator (shared by the vyatta-family flavors). Kept as an
+// explicit list rather than a broad regex to avoid false positives on unrelated
+// text that merely contains the word "failed". The canonical (title-cased)
+// form is returned to callers for diagnostics; matching itself is
+// case-insensitive.
+var applyFailureMarkers = []string{
+	"Set failed",
+	"Commit failed",
+	"Delete failed",
+}
+
+// ApplyOutputIndicatesFailure reports whether combined apply output (stdout+stderr)
+// from the router's vbash apply script contains a failure marker that the guest
+// exit code can mask (a set-time validation failure still lets `commit` exit 0
+// when `load` left a committable diff). Returns the matched marker for diagnostics.
+//
+// Matching is case-insensitive against a curated marker list; the first marker
+// found is returned. When no marker is present it returns ("", false).
+func ApplyOutputIndicatesFailure(output string) (marker string, failed bool) {
+	lower := strings.ToLower(output)
+	for _, m := range applyFailureMarkers {
+		if strings.Contains(lower, strings.ToLower(m)) {
+			return m, true
+		}
+	}
+	return "", false
+}

--- a/internal/provider/qga/failure_marker_test.go
+++ b/internal/provider/qga/failure_marker_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package qga
+
+import "testing"
+
+// invalidAddressOutput is the exact combined output observed on a real guest
+// when a set-time validation failure occurs: `commit` still exits 0 (the
+// preceding `load` left a committable diff), so only the "Set failed" text in
+// the output reveals the failure.
+const invalidAddressOutput = `Load complete. Use 'commit' to make changes effective.
+  Error: not-an-ip is not a valid network interface address
+  Invalid value
+  Value validation failed
+  Set failed`
+
+func TestApplyOutputIndicatesFailure(t *testing.T) {
+	tests := []struct {
+		name       string
+		output     string
+		wantFailed bool
+		wantMarker string
+	}{
+		{
+			name:       "set failure from real invalid-address output",
+			output:     invalidAddressOutput,
+			wantFailed: true,
+			wantMarker: "Set failed",
+		},
+		{
+			name:       "set failed marker",
+			output:     "Set failed",
+			wantFailed: true,
+			wantMarker: "Set failed",
+		},
+		{
+			name:       "commit failed marker",
+			output:     "some noise\nCommit failed\nmore noise",
+			wantFailed: true,
+			wantMarker: "Commit failed",
+		},
+		{
+			name:       "delete failed marker",
+			output:     "Delete failed",
+			wantFailed: true,
+			wantMarker: "Delete failed",
+		},
+		{
+			name:       "case-insensitive match",
+			output:     "  set FAILED",
+			wantFailed: true,
+			wantMarker: "Set failed",
+		},
+		{
+			name:       "clean success output does not match",
+			output:     "Load complete. Use 'commit' to make changes effective.",
+			wantFailed: false,
+			wantMarker: "",
+		},
+		{
+			name:       "empty output does not match",
+			output:     "",
+			wantFailed: false,
+			wantMarker: "",
+		},
+		{
+			name:       "unrelated failure word does not match",
+			output:     "failed to reach neighbor",
+			wantFailed: false,
+			wantMarker: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			marker, failed := ApplyOutputIndicatesFailure(tt.output)
+			if failed != tt.wantFailed {
+				t.Errorf("failed = %v, want %v", failed, tt.wantFailed)
+			}
+			if marker != tt.wantMarker {
+				t.Errorf("marker = %q, want %q", marker, tt.wantMarker)
+			}
+		})
+	}
+}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -37,6 +37,14 @@ var (
 	// isCertManagerAlreadyInstalled will be set true when CertManager CRDs be found on the cluster
 	isCertManagerAlreadyInstalled = false
 
+	// e2eCluster selects the target cluster flavor and must stay in sync with the
+	// Makefile's E2E_CLUSTER variable. The default (empty or "kind") builds and
+	// `kind load`s the manager image into a throwaway Kind cluster. Set
+	// E2E_CLUSTER=k3s to target a pre-provisioned single-node k3s cluster (e.g.
+	// the KubeVirt CI job), in which case the image is imported into the node's
+	// containerd instead.
+	e2eCluster = os.Getenv("E2E_CLUSTER")
+
 	// projectImage is the name of the image which will be build and loaded
 	// with the code source changes to be tested.
 	projectImage = "example.com/vrouter-operator:v0.0.1"
@@ -58,11 +66,17 @@ var _ = BeforeSuite(func() {
 	_, err := utils.Run(cmd)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the manager(Operator) image")
 
-	// TODO(user): If you want to change the e2e test vendor from Kind, ensure the image is
-	// built and available before running the tests. Also, remove the following block.
-	By("loading the manager(Operator) image on Kind")
-	err = utils.LoadImageToKindClusterWithName(projectImage)
-	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the manager(Operator) image into Kind")
+	// Make the freshly built image available to the target cluster. Kind loads it
+	// directly; a pre-provisioned k3s cluster imports it into the node containerd.
+	if e2eCluster == "k3s" {
+		By("importing the manager(Operator) image into the k3s node containerd")
+		err = utils.LoadImageToK3sContainerd(projectImage)
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to import the manager(Operator) image into k3s containerd")
+	} else {
+		By("loading the manager(Operator) image on Kind")
+		err = utils.LoadImageToKindClusterWithName(projectImage)
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the manager(Operator) image into Kind")
+	}
 
 	// The tests-e2e are intended to run on a temporary cluster that is created and destroyed for testing.
 	// To prevent errors when tests run in environments with CertManager already installed,

--- a/test/e2e/kubevirt_e2e_test.go
+++ b/test/e2e/kubevirt_e2e_test.go
@@ -1,0 +1,505 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/tjjh89017/vrouter-operator/test/utils"
+)
+
+// KubeVirt provider real-data-path e2e (issue #38, item E2 — happy path only).
+//
+// This suite exercises the KubeVirt provider end to end against a live
+// k3s+KubeVirt cluster with hardware virtualization: it boots a real
+// virtual-router guest VM, points a VRouterConfig at it (via a VRouterTarget),
+// and asserts the operator drives the guest to Applied/Ready, then verifies the
+// applied configuration INSIDE the guest via QGA.
+//
+// CR wiring (minimal path that genuinely exercises CheckReady -> apply ->
+// status): a single VRouterTarget + VRouterConfig pair. VRouterConfig is the CR
+// the VRouterController reconciles; its spec.targetRef points at a VRouterTarget
+// that carries the KubeVirt ProviderConfig (spec.provider.kubevirt.name = the
+// VM name). A VRouterBinding+Template+Params chain is NOT used: it would only
+// *generate* VRouterConfigs, which then reconcile through the exact same KubeVirt
+// data path — adding indirection without exercising more of the provider. The
+// validating webhook (internal/webhook/v1/vrouterconfig_webhook.go) requires
+// spec.targetRef to resolve to an existing VRouterTarget in the SAME namespace,
+// so both CRs live in the VM's namespace and the Target is created first.
+//
+// Guard: the whole suite is skipped unless E2E_CLUSTER=k3s, because it needs a
+// real KubeVirt + KVM node. The default Kind suite must never run it.
+//
+// Structured so item E3 can append a failure-path It(...) to the same Describe.
+var _ = Describe("KubeVirt provider data path", Ordered, Label("kubevirt-e2e"), func() {
+	const (
+		// The VM, VRouterTarget and VRouterConfig all live here. The KubeVirt
+		// provider resolves kubevirt.namespace to the VRouterTarget's own
+		// namespace when omitted; keeping everything in one namespace also
+		// satisfies the same-namespace targetRef webhook rule.
+		kvNamespace = "default"
+		vmName      = "vrouter-e2e-kubevirt"
+		targetName  = "vrouter-e2e-kubevirt"
+		configName  = "vrouter-e2e-kubevirt-config"
+		// failConfigName is the E3 failure-path VRouterConfig. It targets the
+		// same VRouterTarget/VM as the happy path but applies a config that
+		// fails to commit in-guest; it is created and cleaned up inside the
+		// failure-path It so it never perturbs the happy-path config CR.
+		failConfigName = "vrouter-e2e-kubevirt-fail"
+
+		// appliedHostname is the deterministic system host-name the config sets.
+		// It is observable inside the guest: after `set system host-name` is
+		// committed, the guest's live hostname reflects it. Kept purely
+		// alphanumeric to stay within the router's host-name validation.
+		appliedHostname = "vre2ehost"
+
+		// Generous first-boot budget: guest boot + qemu-guest-agent coming up on
+		// hardware-accelerated KVM.
+		vmReadyTimeout = 10 * time.Minute
+		// Generous apply budget. The guest's router unit is a oneshot that only
+		// settles to active(exited) ~15s AFTER AgentConnected, and CheckReady
+		// polls SubState until "exited" before dispatching — so the operator may
+		// legitimately spend minutes before Applied. NEVER assert once.
+		applyTimeout = 10 * time.Minute
+		applyPoll    = 15 * time.Second
+		// failTimeout is the failure-path budget. A genuine commit-time rejection
+		// surfaces within seconds of the operator dispatching the exec, so the
+		// generous 10m applyTimeout only wastes CI time here — 4m still absorbs
+		// scheduling/QGA latency while failing fast if the config is wrong.
+		failTimeout = 4 * time.Minute
+	)
+
+	var (
+		// routerContainerDisk is the containerDisk image booted as the guest
+		// virtual router. A LATER CI item (the k3s workflow) is responsible for
+		// building and importing this image into the node's containerd; this
+		// spec only references it by tag.
+		routerContainerDisk string
+		// launcherPod is the virt-launcher pod hosting the VMI; QGA commands are
+		// issued via `virsh qemu-agent-command` inside its `compute` container.
+		launcherPod string
+		// qgaDomain is the libvirt domain name virsh addresses: "<ns>_<vm>".
+		qgaDomain string
+	)
+
+	BeforeAll(func() {
+		if e2eCluster != "k3s" {
+			Skip("KubeVirt provider e2e requires E2E_CLUSTER=k3s (real KubeVirt + KVM); skipping on the default Kind suite")
+		}
+
+		routerContainerDisk = os.Getenv("E2E_ROUTER_CONTAINERDISK")
+		if routerContainerDisk == "" {
+			routerContainerDisk = "dozenos-e2e:latest"
+		}
+		qgaDomain = fmt.Sprintf("%s_%s", kvNamespace, vmName)
+
+		// Ensure the operator is installed and running. This suite is designed to
+		// be run on its own (the k3s CI job focuses --label=kubevirt-e2e), so it
+		// deploys the operator itself rather than depending on the Kind-oriented
+		// "Manager" suite's ordering. make install / make deploy are idempotent
+		// `kubectl apply`s (make deploy also creates the operator namespace).
+		By("installing CRDs")
+		_, err := utils.Run(exec.Command("make", "install"))
+		Expect(err).NotTo(HaveOccurred(), "Failed to install CRDs")
+
+		By("deploying the controller-manager")
+		_, err = utils.Run(exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectImage)))
+		Expect(err).NotTo(HaveOccurred(), "Failed to deploy the controller-manager")
+
+		By("waiting for the controller-manager deployment to be Available")
+		Eventually(func(g Gomega) {
+			cmd := exec.Command("kubectl", "wait",
+				"deployment.apps/vrouter-operator-controller-manager",
+				"--for", "condition=Available",
+				"--namespace", namespace,
+				"--timeout", "60s",
+			)
+			_, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+		}, 5*time.Minute, 10*time.Second).Should(Succeed())
+
+		By("creating the guest virtual-router VirtualMachine")
+		Expect(applyManifest(virtualMachineManifest(vmName, kvNamespace, routerContainerDisk))).
+			To(Succeed(), "Failed to create the VirtualMachine")
+
+		By("waiting for the VM to become Ready (VMI created + running)")
+		Eventually(func(g Gomega) {
+			cmd := exec.Command("kubectl", "-n", kvNamespace, "wait",
+				fmt.Sprintf("vm/%s", vmName),
+				"--for", "condition=Ready",
+				"--timeout", "60s",
+			)
+			_, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+		}, vmReadyTimeout, 15*time.Second).Should(Succeed())
+
+		By("waiting for the qemu-guest-agent to connect (VMI AgentConnected)")
+		Eventually(func(g Gomega) {
+			cmd := exec.Command("kubectl", "-n", kvNamespace, "wait",
+				fmt.Sprintf("vmi/%s", vmName),
+				"--for", "condition=AgentConnected",
+				"--timeout", "60s",
+			)
+			_, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+		}, vmReadyTimeout, 15*time.Second).Should(Succeed())
+
+		By("locating the virt-launcher pod for QGA verification")
+		Eventually(func(g Gomega) {
+			cmd := exec.Command("kubectl", "-n", kvNamespace, "get", "pod",
+				"-l", fmt.Sprintf("vm.kubevirt.io/name=%s", vmName),
+				"-o", "jsonpath={.items[0].metadata.name}",
+			)
+			out, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			launcherPod = strings.TrimSpace(out)
+			g.Expect(launcherPod).NotTo(BeEmpty(), "virt-launcher pod not found yet")
+		}).Should(Succeed())
+	})
+
+	AfterAll(func() {
+		if e2eCluster != "k3s" {
+			return
+		}
+		By("deleting the VRouterConfig")
+		_, _ = utils.Run(exec.Command(
+			"kubectl", "-n", kvNamespace,
+			"delete", "vrouterconfig", configName, "--ignore-not-found"))
+		By("deleting the VRouterTarget")
+		_, _ = utils.Run(exec.Command(
+			"kubectl", "-n", kvNamespace,
+			"delete", "vroutertarget", targetName, "--ignore-not-found"))
+		By("deleting the VirtualMachine")
+		_, _ = utils.Run(exec.Command("kubectl", "-n", kvNamespace, "delete", "vm", vmName, "--ignore-not-found"))
+	})
+
+	It("drives the guest to Applied/Ready and applies the config in-guest", func() {
+		By("creating the VRouterTarget that identifies the VM by name")
+		Expect(applyManifest(vrouterTargetManifest(targetName, kvNamespace, vmName))).
+			To(Succeed(), "Failed to create the VRouterTarget")
+
+		By("creating the VRouterConfig that sets a deterministic system host-name")
+		Expect(applyManifest(vrouterConfigManifest(configName, kvNamespace, targetName, appliedHostname))).
+			To(Succeed(), "Failed to create the VRouterConfig")
+
+		By("waiting for the VRouterConfig Applied condition to become True and observedGeneration to catch up")
+		Eventually(func(g Gomega) {
+			generation := getJSONPath(g, configName, "{.metadata.generation}")
+			observedGeneration := getJSONPath(g, configName, "{.status.observedGeneration}")
+			appliedStatus := getJSONPath(g, configName,
+				`{.status.conditions[?(@.type=="Applied")].status}`)
+
+			g.Expect(observedGeneration).NotTo(BeEmpty(), "observedGeneration not set yet")
+			g.Expect(observedGeneration).To(Equal(generation),
+				"status.observedGeneration has not caught up with metadata.generation")
+			g.Expect(appliedStatus).To(Equal("True"), "Applied condition is not True yet")
+		}, applyTimeout, applyPoll).Should(Succeed())
+
+		By("verifying the applied host-name is present in the guest via QGA")
+		Eventually(func(g Gomega) {
+			out, err := qgaGuestExec(kvNamespace, launcherPod, qgaDomain, "/bin/hostname")
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(strings.TrimSpace(out)).To(Equal(appliedHostname),
+				"guest hostname does not reflect the applied config yet")
+		}, applyTimeout, applyPoll).Should(Succeed())
+	})
+
+	// Item E3 appends the failure-path It(...) here, reusing the VM booted in
+	// BeforeAll and the qgaGuestExec/getJSONPath helpers below.
+	It("marks the config Failed with Applied=False on a commit failure and does not auto-retry", func() {
+		By("creating a VRouterConfig whose commands pass `set` but fail at `commit` in-guest")
+		Expect(applyManifest(vrouterFailingConfigManifest(failConfigName, kvNamespace, targetName))).
+			To(Succeed(), "Failed to create the failing VRouterConfig")
+		DeferCleanup(func() {
+			_, _ = utils.Run(exec.Command(
+				"kubectl", "-n", kvNamespace,
+				"delete", "vrouterconfig", failConfigName, "--ignore-not-found"))
+		})
+
+		By("waiting for the VRouterConfig to reach phase=Failed with Applied=False")
+		Eventually(func(g Gomega) {
+			phase := getJSONPath(g, failConfigName, "{.status.phase}")
+			appliedStatus := getJSONPath(g, failConfigName,
+				`{.status.conditions[?(@.type=="Applied")].status}`)
+			// Capture the live reason/message too so a timeout log shows the
+			// config's ACTUAL observed state (e.g. it wrongly reached Applied)
+			// instead of a bare "timed out" — the last poll's diag is what
+			// Gomega prints on failure.
+			appliedReason := getJSONPath(g, failConfigName,
+				`{.status.conditions[?(@.type=="Applied")].reason}`)
+			appliedMessage := getJSONPath(g, failConfigName,
+				`{.status.conditions[?(@.type=="Applied")].message}`)
+			diag := fmt.Sprintf(
+				"last observed: phase=%q Applied.status=%q Applied.reason=%q Applied.message=%q",
+				phase, appliedStatus, appliedReason, appliedMessage)
+			g.Expect(phase).To(Equal("Failed"), "phase has not reached Failed yet; %s", diag)
+			g.Expect(appliedStatus).To(Equal("False"), "Applied condition is not False; %s", diag)
+		}, failTimeout, applyPoll).Should(Succeed())
+
+		By("recording the observedGeneration stamped for the failed dispatch")
+		var failedObservedGeneration string
+		Eventually(func(g Gomega) {
+			failedObservedGeneration = getJSONPath(g, failConfigName, "{.status.observedGeneration}")
+			g.Expect(failedObservedGeneration).NotTo(BeEmpty(), "observedGeneration not set yet")
+		}).Should(Succeed())
+
+		// Per SPEC §7.2, a Failed config has NO auto-retry: the controller only
+		// re-dispatches on a new generation or a fresh target reboot, neither of
+		// which happens here. A retry would flip phase back to Applying and set a
+		// fresh execPID; on failure execPID is cleared (empty) and
+		// observedGeneration is left at the generation the exec was dispatched
+		// for. So the invariant of "no retry" is: phase stays Failed, execPID
+		// stays empty, observedGeneration does not advance.
+		By("verifying the operator does not auto-retry the Failed config over a stable window")
+		Consistently(func(g Gomega) {
+			phase := getJSONPath(g, failConfigName, "{.status.phase}")
+			execPID := getJSONPath(g, failConfigName, "{.status.execPID}")
+			observedGeneration := getJSONPath(g, failConfigName, "{.status.observedGeneration}")
+			g.Expect(phase).To(Equal("Failed"), "phase left Failed — operator re-dispatched")
+			g.Expect(execPID).To(BeEmpty(), "execPID re-populated — operator re-dispatched an exec")
+			g.Expect(observedGeneration).To(Equal(failedObservedGeneration),
+				"observedGeneration advanced — operator re-dispatched")
+		}, 45*time.Second, 5*time.Second).Should(Succeed())
+	})
+})
+
+// virtualMachineManifest renders a KubeVirt VirtualMachine (runStrategy=Always)
+// booting the given containerDisk image as the guest virtual router. Mirrors the
+// proven probe manifest (.github/workflows/e2e-kubevirt-probe.yml): a real VM
+// (not a bare VMI) so it exercises the same object the operator targets by name.
+func virtualMachineManifest(name, ns, image string) string {
+	return fmt.Sprintf(`apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: %[1]s
+  namespace: %[2]s
+spec:
+  runStrategy: Always
+  template:
+    metadata:
+      labels:
+        kubevirt.io/vm: %[1]s
+    spec:
+      terminationGracePeriodSeconds: 0
+      domain:
+        cpu:
+          cores: 2
+        machine:
+          type: q35
+        resources:
+          requests:
+            memory: 2Gi
+        devices:
+          disks:
+            - name: containerdisk
+              disk:
+                bus: virtio
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: %[3]s
+            imagePullPolicy: IfNotPresent
+`, name, ns, image)
+}
+
+// vrouterTargetManifest renders a VRouterTarget whose KubeVirt ProviderConfig
+// identifies the VM by name (spec.provider.kubevirt.name, per SPEC §9.6).
+func vrouterTargetManifest(name, ns, vmName string) string {
+	return fmt.Sprintf(`apiVersion: vrouter.kojuro.date/v1
+kind: VRouterTarget
+metadata:
+  name: %[1]s
+  namespace: %[2]s
+spec:
+  provider:
+    type: kubevirt
+    kubevirt:
+      name: %[3]s
+      namespace: %[2]s
+`, name, ns, vmName)
+}
+
+// vrouterConfigManifest renders a VRouterConfig that sets a deterministic system
+// host-name via the commands field (mirroring config/samples). The commands
+// block is injected into the provider's internal vbash template (SPEC §7.4),
+// committed (and saved) in-guest; the resulting live hostname is what the QGA
+// check asserts.
+func vrouterConfigManifest(name, ns, targetName, hostname string) string {
+	return fmt.Sprintf(`apiVersion: vrouter.kojuro.date/v1
+kind: VRouterConfig
+metadata:
+  name: %[1]s
+  namespace: %[2]s
+spec:
+  targetRef:
+    name: %[3]s
+  commands: |
+    set system host-name '%[4]s'
+`, name, ns, targetName, hostname)
+}
+
+// vrouterFailingConfigManifest renders a VRouterConfig that is accepted by the
+// K8s schema/webhook but fails inside the guest, driving the config to
+// phase=Failed / Applied=False (SPEC §7.2).
+//
+// The command assigns an invalid value ('not-an-ip') to eth0's interface address.
+// The router's config validator rejects this at SET time — configure mode prints
+// "Value validation failed / Set failed" and the `set` returns non-zero. The apply
+// template (SPEC §7.4) has NO `set -e`, so the script keeps running through to
+// `commit`. Crucially, because a preceding `load` already left a committable diff,
+// `commit` still exits 0 — the guest exit code MASKS the set-time failure. This
+// exit-0-on-set-failure was confirmed empirically by running this exact config
+// through the real guest apply path in CI. The operator therefore detects the
+// failure by scanning the apply output for the "Set failed" marker (SPEC §7.4) and
+// reports phase=Failed / Applied=False even though the exit code is 0.
+//
+// save is false on purpose: it keeps the apply path minimal (no post-commit
+// `save` step) so the failure surfaces purely as the "Set failed" marker in the
+// configure-mode output that the operator scans for.
+func vrouterFailingConfigManifest(name, ns, targetName string) string {
+	return fmt.Sprintf(`apiVersion: vrouter.kojuro.date/v1
+kind: VRouterConfig
+metadata:
+  name: %[1]s
+  namespace: %[2]s
+spec:
+  targetRef:
+    name: %[3]s
+  save: false
+  commands: |
+    set interfaces ethernet eth0 address 'not-an-ip'
+`, name, ns, targetName)
+}
+
+// applyManifest pipes a rendered manifest into `kubectl apply -f -`.
+func applyManifest(manifest string) error {
+	cmd := exec.Command("kubectl", "apply", "-f", "-")
+	cmd.Stdin = strings.NewReader(manifest)
+	_, err := utils.Run(cmd)
+	return err
+}
+
+// getJSONPath reads a jsonpath expression off the named VRouterConfig, failing
+// the enclosing Eventually block (via the supplied Gomega) on error.
+func getJSONPath(g Gomega, configName, jsonpath string) string {
+	cmd := exec.Command("kubectl", "-n", "default", "get", "vrouterconfig", configName,
+		"-o", fmt.Sprintf("jsonpath=%s", jsonpath))
+	out, err := utils.Run(cmd)
+	g.Expect(err).NotTo(HaveOccurred())
+	return strings.TrimSpace(out)
+}
+
+// guestExecCommand is a qemu-guest-agent guest-exec request.
+type guestExecCommand struct {
+	Execute   string             `json:"execute"`
+	Arguments guestExecArguments `json:"arguments"`
+}
+
+type guestExecArguments struct {
+	Path          string   `json:"path"`
+	Arg           []string `json:"arg,omitempty"`
+	CaptureOutput bool     `json:"capture-output"`
+}
+
+// qgaGuestExec runs a command inside the guest via QGA and returns its decoded
+// stdout. It mirrors the proven probe recon pattern
+// (.github/workflows/e2e-kubevirt-probe.yml) and the operator's own runQGA:
+// dispatch guest-exec inside the virt-launcher `compute` container with virsh,
+// poll guest-exec-status until the process exits, then base64-decode out-data.
+func qgaGuestExec(ns, launcher, domain, path string, args ...string) (string, error) {
+	payload, err := json.Marshal(guestExecCommand{
+		Execute: "guest-exec",
+		Arguments: guestExecArguments{
+			Path:          path,
+			Arg:           args,
+			CaptureOutput: true,
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("marshal guest-exec command: %w", err)
+	}
+
+	resp, err := virshQGA(ns, launcher, domain, string(payload))
+	if err != nil {
+		return "", fmt.Errorf("guest-exec dispatch: %w", err)
+	}
+	var pidResp struct {
+		Return struct {
+			Pid int64 `json:"pid"`
+		} `json:"return"`
+	}
+	if err := json.Unmarshal([]byte(resp), &pidResp); err != nil {
+		return "", fmt.Errorf("parse guest-exec pid from %q: %w", resp, err)
+	}
+	if pidResp.Return.Pid == 0 {
+		return "", fmt.Errorf("no pid in guest-exec response: %s", resp)
+	}
+
+	for i := 0; i < 120; i++ {
+		statusPayload := fmt.Sprintf(`{"execute":"guest-exec-status","arguments":{"pid":%d}}`, pidResp.Return.Pid)
+		statusResp, err := virshQGA(ns, launcher, domain, statusPayload)
+		if err != nil {
+			return "", fmt.Errorf("guest-exec-status: %w", err)
+		}
+		var status struct {
+			Return struct {
+				Exited   bool   `json:"exited"`
+				ExitCode int    `json:"exitcode"`
+				OutData  string `json:"out-data"`
+				ErrData  string `json:"err-data"`
+			} `json:"return"`
+		}
+		if err := json.Unmarshal([]byte(statusResp), &status); err != nil {
+			return "", fmt.Errorf("parse guest-exec-status from %q: %w", statusResp, err)
+		}
+		if status.Return.Exited {
+			if status.Return.ExitCode != 0 {
+				stderr, _ := base64.StdEncoding.DecodeString(status.Return.ErrData)
+				return "", fmt.Errorf("guest-exec %s exited non-zero (exitCode=%d stderr=%s)",
+					path, status.Return.ExitCode, strings.TrimSpace(string(stderr)))
+			}
+			if status.Return.OutData == "" {
+				return "", nil
+			}
+			decoded, err := base64.StdEncoding.DecodeString(status.Return.OutData)
+			if err != nil {
+				return "", fmt.Errorf("decode guest-exec out-data: %w", err)
+			}
+			return string(decoded), nil
+		}
+		time.Sleep(time.Second)
+	}
+	return "", fmt.Errorf("guest-exec %s timed out waiting for exit", path)
+}
+
+// virshQGA issues a raw qemu-guest-agent JSON command via `virsh
+// qemu-agent-command` inside the virt-launcher `compute` container — exactly how
+// the operator's KubeVirt provider talks to the guest.
+func virshQGA(ns, launcher, domain, agentJSON string) (string, error) {
+	cmd := exec.Command("kubectl", "-n", ns, "exec", launcher, "-c", "compute", "--",
+		"virsh", "qemu-agent-command", domain, agentJSON)
+	return utils.Run(cmd)
+}

--- a/test/e2e/kubevirt_e2e_test.go
+++ b/test/e2e/kubevirt_e2e_test.go
@@ -287,8 +287,7 @@ var _ = Describe("KubeVirt provider data path", Ordered, Label("kubevirt-e2e"), 
 })
 
 // virtualMachineManifest renders a KubeVirt VirtualMachine (runStrategy=Always)
-// booting the given containerDisk image as the guest virtual router. Mirrors the
-// proven probe manifest (.github/workflows/e2e-kubevirt-probe.yml): a real VM
+// booting the given containerDisk image as the guest virtual router. A real VM
 // (not a bare VMI) so it exercises the same object the operator targets by name.
 func virtualMachineManifest(name, ns, image string) string {
 	return fmt.Sprintf(`apiVersion: kubevirt.io/v1
@@ -425,10 +424,9 @@ type guestExecArguments struct {
 }
 
 // qgaGuestExec runs a command inside the guest via QGA and returns its decoded
-// stdout. It mirrors the proven probe recon pattern
-// (.github/workflows/e2e-kubevirt-probe.yml) and the operator's own runQGA:
-// dispatch guest-exec inside the virt-launcher `compute` container with virsh,
-// poll guest-exec-status until the process exits, then base64-decode out-data.
+// stdout. It mirrors the operator's own runQGA: dispatch guest-exec inside the
+// virt-launcher `compute` container with virsh, poll guest-exec-status until the
+// process exits, then base64-decode out-data.
 func qgaGuestExec(ns, launcher, domain, path string, args ...string) (string, error) {
 	payload, err := json.Marshal(guestExecCommand{
 		Execute: "guest-exec",

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -177,6 +177,52 @@ func LoadImageToKindClusterWithName(name string) error {
 	return err
 }
 
+// LoadImageToK3sContainerd imports a local docker image into the k3s node's
+// containerd image store. Used when the e2e suite targets a pre-provisioned
+// single-node k3s cluster instead of Kind (see the KubeVirt CI job). k3s ctr
+// defaults to the k8s.io containerd namespace that the kubelet reads, so the
+// imported image is available to pods without pushing to a registry. This
+// mirrors the proven CI step: `docker save <name> | sudo k3s ctr images import -`.
+func LoadImageToK3sContainerd(name string) error {
+	// Stream the docker image tarball straight into k3s containerd rather than
+	// buffering it to disk: docker save (stdout) -> k3s ctr images import (stdin).
+	saveCmd := exec.Command("docker", "save", name)
+	importCmd := exec.Command("sudo", "k3s", "ctr", "images", "import", "-")
+
+	pipe, err := saveCmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("failed to create docker save pipe: %w", err)
+	}
+	importCmd.Stdin = pipe
+
+	var importOut bytes.Buffer
+	importCmd.Stdout = &importOut
+	importCmd.Stderr = &importOut
+
+	if err := importCmd.Start(); err != nil {
+		return fmt.Errorf("failed to start k3s ctr images import: %w", err)
+	}
+	if err := saveCmd.Run(); err != nil {
+		return fmt.Errorf("failed to run docker save %q: %w", name, err)
+	}
+	if err := importCmd.Wait(); err != nil {
+		return fmt.Errorf("k3s ctr images import failed: %q: %w", importOut.String(), err)
+	}
+
+	// Verify the image landed in the containerd namespace the kubelet reads.
+	verifyCmd := exec.Command("sudo", "k3s", "ctr", "images", "ls", "-q")
+	output, err := Run(verifyCmd)
+	if err != nil {
+		return fmt.Errorf("failed to list k3s containerd images: %w", err)
+	}
+	for _, line := range GetNonEmptyLines(output) {
+		if strings.Contains(line, name) {
+			return nil
+		}
+	}
+	return fmt.Errorf("image %q not found in k3s containerd after import", name)
+}
+
 // GetNonEmptyLines converts given command output string into individual objects
 // according to line breakers, and ignores the empty elements in it.
 func GetNonEmptyLines(output string) []string {


### PR DESCRIPTION
Implements issue #38 — a real KubeVirt provider e2e job on GitHub Actions
(k3s single-node + hardware KVM, DozenOS guest), plus the operator changes the
suite exercises.

## What this PR contains

**Operator changes**

- **Guest OS flavor detection** (`internal/provider/flavor`): the KubeVirt
  provider reads `/etc/os-release` over QGA and resolves the guest's router
  systemd unit from its `ID` field instead of hardcoding `vyos-router.service`.
  Unknown IDs surface loudly as an error rather than defaulting. Registered
  flavors: `vyos` → `vyos-router.service`, `dozenos` → `dozenos-router.service`.
- **Apply failure marker** (`internal/provider/qga/failure_marker.go`): the
  guest exit code is not the sole success signal. A set-time validation failure
  prints an error but still lets `commit` exit 0 (the preceding `load` left a
  committable diff), masking the failure. The controller now also scans the
  combined apply output for a curated marker list (`Set failed` / `Commit
  failed` / `Delete failed`, case-insensitive) and reports `phase=Failed` on a
  match even when `exitCode == 0`. Documented in SPEC §7.4.

**e2e suite + CI**

- `.github/workflows/e2e-kubevirt.yml`: acceptance-gate job that enables
  `/dev/kvm` via udev (fails fast if absent — no TCG fallback), raises inotify
  limits, installs pinned k3s + KubeVirt + virtctl + cert-manager, resolves the
  latest DozenOS KVM qcow2 via its `version.json`, verifies the sha256, wraps it
  in a containerDisk and imports it into the node containerd, then runs the
  labeled ginkgo suite.
- `test/e2e/kubevirt_e2e_test.go`: full happy-path + failure-path spec (label
  `kubevirt-e2e`). Boots a real DozenOS guest, drives a VRouterConfig to
  Applied/Ready and verifies the applied host-name inside the guest via QGA;
  the failure-path spec asserts `phase=Failed` / `Applied=False` on a set-time
  rejection and that the operator does not auto-retry.
- Makefile: `E2E_CLUSTER=k3s` targets a pre-provisioned cluster (setup/cleanup
  become no-ops; image imported into node containerd), `GINKGO_LABEL_FILTER`
  focuses the labeled spec, `E2E_TIMEOUT` bounds the long VM-boot run. Kind path
  unchanged.

Hardware virtualization is REQUIRED; the job fails fast if `/dev/kvm` is absent.

Refs #38
