### PR TITLE
test(e2e): VRouterBinding serial rollout e2e suite

### DIFF
--- a/.github/workflows/e2e-kubevirt.yml
+++ b/.github/workflows/e2e-kubevirt.yml
@@ -1,17 +1,22 @@
 name: E2E KubeVirt
 
-# Acceptance-gate workflow for issue #38: stand up the full environment on a
-# hosted runner and run the KubeVirt provider e2e suite (ginkgo label
-# "kubevirt-e2e"). It stands up k3s + KubeVirt + a real DozenOS containerDisk
-# guest booted on hardware KVM, plus the pieces the suite needs: a Go toolchain
-# to run `go test`, and a DozenOS containerDisk tagged for the spec.
+# Acceptance-gate workflow for issue #38 (KubeVirt provider, ginkgo label
+# "kubevirt-e2e") and issue #35's serial rollout feature (ginkgo label
+# "rollout-e2e", test/e2e/rollout_e2e_test.go). It stands up k3s + KubeVirt +
+# a real DozenOS containerDisk guest booted on hardware KVM, plus the pieces
+# the suites need: a Go toolchain to run `go test`, and a DozenOS containerDisk
+# tagged for both suites. rollout-e2e boots two guest VMs (kubevirt-e2e's own
+# VM is freed by its AfterAll before rollout-e2e's BeforeAll boots its pair),
+# so timeout-minutes is raised from the original 40 to comfortably cover the
+# extra ~10m boot budget for a second VM plus rollout-e2e's four multi-minute
+# Eventually/Consistently specs on top of the existing kubevirt-e2e budget.
 #
 # What this workflow deliberately does NOT do (the suite owns it, so doing it
 # here would double-work or conflict):
 #   - build/import the operator image: the suite's BeforeSuite runs
 #     `make docker-build` + LoadImageToK3sContainerd(projectImage) itself.
-#   - install CRDs / deploy the controller: the kubevirt-e2e spec's BeforeAll
-#     runs `make install` + `make deploy` itself.
+#   - install CRDs / deploy the controller: each labeled spec's own BeforeAll
+#     runs `make install` + `make deploy` itself (both idempotent).
 #
 # cert-manager IS installed here (the "Install cert-manager (pinned)" step),
 # early and on an un-contended node, because on this single k3s node the
@@ -55,7 +60,7 @@ jobs:
   e2e-kubevirt:
     name: KubeVirt provider e2e
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 70
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -177,7 +182,7 @@ jobs:
           sudo k3s ctr images ls | grep -i "dozenos-e2e" \
             || { echo "guest containerDisk image missing from containerd" >&2; exit 1; }
 
-      - name: Run KubeVirt provider e2e suite
+      - name: Run KubeVirt provider + rollout e2e suites
         env:
           # cert-manager is already installed by the workflow step above, so
           # tell the suite to skip both its BeforeSuite install and (crucially)
@@ -185,13 +190,21 @@ jobs:
           CERT_MANAGER_INSTALL_SKIP: "true"
         run: |
           set -euo pipefail
-          # The suite's BeforeSuite builds + imports the operator image; the
-          # kubevirt-e2e spec's BeforeAll runs `make install` / `make deploy`.
+          # The suite's BeforeSuite builds + imports the operator image; each
+          # labeled spec's own BeforeAll runs `make install` / `make deploy`
+          # (idempotent, so both specs deploying it in the same run is safe).
           # cert-manager is pre-installed by the workflow and left untouched by
-          # the suite (CERT_MANAGER_INSTALL_SKIP above). We only focus the
-          # labeled spec on the pre-provisioned k3s cluster and hand it the
-          # guest containerDisk tag via E2E_ROUTER_CONTAINERDISK (job level).
-          make test-e2e E2E_CLUSTER=k3s GINKGO_LABEL_FILTER=kubevirt-e2e
+          # the suite (CERT_MANAGER_INSTALL_SKIP above). We focus both labeled
+          # specs on the pre-provisioned k3s cluster and hand them the guest
+          # containerDisk tag via E2E_ROUTER_CONTAINERDISK (job level).
+          # E2E_TIMEOUT is raised from the Makefile's 35m default: rollout-e2e
+          # alone boots two VMs and runs four multi-minute specs on top of
+          # kubevirt-e2e's own budget, so the combined `go test` binary needs
+          # more headroom than the Kind-path default assumes. Keep this below
+          # the job's timeout-minutes above so a genuine hang is reported by
+          # `go test`'s own timeout (with goroutine dumps) rather than by the
+          # runner being killed.
+          make test-e2e E2E_CLUSTER=k3s GINKGO_LABEL_FILTER='kubevirt-e2e || rollout-e2e' E2E_TIMEOUT=60m
 
       - name: Collect diagnostics on failure
         if: failure()
@@ -202,12 +215,17 @@ jobs:
           kubectl get pods -A -o wide
           kubectl -n kubevirt get kubevirt kubevirt -o yaml
           echo "----- vrouter CRs -----"
-          kubectl get vrouterconfigs,vroutertargets -A -o wide
+          kubectl get vrouterconfigs,vroutertargets,vrouterbindings,vroutertemplates -A -o wide
           echo "----- VM/VMI describe (default ns) -----"
           kubectl -n default describe vm 2>/dev/null | tail -n 80
           kubectl -n default describe vmi 2>/dev/null | tail -n 80
-          LAUNCHER="$(kubectl -n default get pod -l kubevirt.io=virt-launcher -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)"
-          [ -n "$LAUNCHER" ] && kubectl -n default logs "$LAUNCHER" --all-containers --tail=100
+          # rollout-e2e boots up to two VMs concurrently (kubevirt-e2e's own VM
+          # is freed by then), so dump every virt-launcher pod's logs, not just
+          # the first.
+          for LAUNCHER in $(kubectl -n default get pod -l kubevirt.io=virt-launcher -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+            echo "----- virt-launcher pod: ${LAUNCHER} -----"
+            kubectl -n default logs "$LAUNCHER" --all-containers --tail=100
+          done
           echo "----- controller-manager logs -----"
           kubectl -n vrouter-operator-system get pods -o wide
           kubectl -n vrouter-operator-system logs deployment/vrouter-operator-controller-manager --all-containers --tail=200

--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ endif
 
 .PHONY: test-e2e
 test-e2e: setup-test-e2e manifests generate fmt vet ## Run the e2e tests. Expected an isolated Kind environment, or a pre-provisioned cluster via E2E_CLUSTER.
-	KIND_CLUSTER=$(KIND_CLUSTER) E2E_CLUSTER=$(E2E_CLUSTER) go test ./test/e2e/ -v -ginkgo.v -timeout $(E2E_TIMEOUT) $(if $(GINKGO_LABEL_FILTER),-ginkgo.label-filter=$(GINKGO_LABEL_FILTER),)
+	KIND_CLUSTER=$(KIND_CLUSTER) E2E_CLUSTER=$(E2E_CLUSTER) go test ./test/e2e/ -v -ginkgo.v -timeout $(E2E_TIMEOUT) $(if $(GINKGO_LABEL_FILTER),"-ginkgo.label-filter=$(GINKGO_LABEL_FILTER)",)
 	$(MAKE) cleanup-test-e2e E2E_CLUSTER=$(E2E_CLUSTER)
 
 .PHONY: cleanup-test-e2e

--- a/test/e2e/kubevirt_e2e_test.go
+++ b/test/e2e/kubevirt_e2e_test.go
@@ -53,6 +53,28 @@ import (
 // Guard: the whole suite is skipped unless E2E_CLUSTER=k3s, because it needs a
 // real KubeVirt + KVM node. The default Kind suite must never run it.
 //
+// Shared timing budgets. Package-level (rather than per-Describe-local) so
+// both this suite and the rollout-e2e suite (test/e2e/rollout_e2e_test.go),
+// which boots VMs and drives applies the same way, use identical, generous
+// windows instead of drifting copies. NEVER assert once against a live
+// cluster — every check that reads these uses Eventually/Consistently.
+const (
+	// vmReadyTimeout is the generous first-boot budget: guest boot +
+	// qemu-guest-agent coming up on hardware-accelerated KVM.
+	vmReadyTimeout = 10 * time.Minute
+	// applyTimeout is the generous apply budget. The guest's router unit is a
+	// oneshot that only settles to active(exited) ~15s AFTER AgentConnected,
+	// and CheckReady polls SubState until "exited" before dispatching — so the
+	// operator may legitimately spend minutes before Applied.
+	applyTimeout = 10 * time.Minute
+	applyPoll    = 15 * time.Second
+	// failTimeout is the failure-path budget. A genuine commit-time rejection
+	// surfaces within seconds of the operator dispatching the exec, so the
+	// generous 10m applyTimeout only wastes CI time here — 4m still absorbs
+	// scheduling/QGA latency while failing fast if the config is wrong.
+	failTimeout = 4 * time.Minute
+)
+
 // Structured so item E3 can append a failure-path It(...) to the same Describe.
 var _ = Describe("KubeVirt provider data path", Ordered, Label("kubevirt-e2e"), func() {
 	const (
@@ -75,21 +97,6 @@ var _ = Describe("KubeVirt provider data path", Ordered, Label("kubevirt-e2e"), 
 		// committed, the guest's live hostname reflects it. Kept purely
 		// alphanumeric to stay within the router's host-name validation.
 		appliedHostname = "vre2ehost"
-
-		// Generous first-boot budget: guest boot + qemu-guest-agent coming up on
-		// hardware-accelerated KVM.
-		vmReadyTimeout = 10 * time.Minute
-		// Generous apply budget. The guest's router unit is a oneshot that only
-		// settles to active(exited) ~15s AFTER AgentConnected, and CheckReady
-		// polls SubState until "exited" before dispatching — so the operator may
-		// legitimately spend minutes before Applied. NEVER assert once.
-		applyTimeout = 10 * time.Minute
-		applyPoll    = 15 * time.Second
-		// failTimeout is the failure-path budget. A genuine commit-time rejection
-		// surfaces within seconds of the operator dispatching the exec, so the
-		// generous 10m applyTimeout only wastes CI time here — 4m still absorbs
-		// scheduling/QGA latency while failing fast if the config is wrong.
-		failTimeout = 4 * time.Minute
 	)
 
 	var (
@@ -116,68 +123,12 @@ var _ = Describe("KubeVirt provider data path", Ordered, Label("kubevirt-e2e"), 
 		}
 		qgaDomain = fmt.Sprintf("%s_%s", kvNamespace, vmName)
 
-		// Ensure the operator is installed and running. This suite is designed to
-		// be run on its own (the k3s CI job focuses --label=kubevirt-e2e), so it
-		// deploys the operator itself rather than depending on the Kind-oriented
-		// "Manager" suite's ordering. make install / make deploy are idempotent
-		// `kubectl apply`s (make deploy also creates the operator namespace).
-		By("installing CRDs")
-		_, err := utils.Run(exec.Command("make", "install"))
-		Expect(err).NotTo(HaveOccurred(), "Failed to install CRDs")
+		// This suite is designed to be run on its own (the k3s CI job focuses
+		// --label=kubevirt-e2e), so it deploys the operator itself rather than
+		// depending on the Kind-oriented "Manager" suite's ordering.
+		deployOperator()
 
-		By("deploying the controller-manager")
-		_, err = utils.Run(exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectImage)))
-		Expect(err).NotTo(HaveOccurred(), "Failed to deploy the controller-manager")
-
-		By("waiting for the controller-manager deployment to be Available")
-		Eventually(func(g Gomega) {
-			cmd := exec.Command("kubectl", "wait",
-				"deployment.apps/vrouter-operator-controller-manager",
-				"--for", "condition=Available",
-				"--namespace", namespace,
-				"--timeout", "60s",
-			)
-			_, err := utils.Run(cmd)
-			g.Expect(err).NotTo(HaveOccurred())
-		}, 5*time.Minute, 10*time.Second).Should(Succeed())
-
-		By("creating the guest virtual-router VirtualMachine")
-		Expect(applyManifest(virtualMachineManifest(vmName, kvNamespace, routerContainerDisk))).
-			To(Succeed(), "Failed to create the VirtualMachine")
-
-		By("waiting for the VM to become Ready (VMI created + running)")
-		Eventually(func(g Gomega) {
-			cmd := exec.Command("kubectl", "-n", kvNamespace, "wait",
-				fmt.Sprintf("vm/%s", vmName),
-				"--for", "condition=Ready",
-				"--timeout", "60s",
-			)
-			_, err := utils.Run(cmd)
-			g.Expect(err).NotTo(HaveOccurred())
-		}, vmReadyTimeout, 15*time.Second).Should(Succeed())
-
-		By("waiting for the qemu-guest-agent to connect (VMI AgentConnected)")
-		Eventually(func(g Gomega) {
-			cmd := exec.Command("kubectl", "-n", kvNamespace, "wait",
-				fmt.Sprintf("vmi/%s", vmName),
-				"--for", "condition=AgentConnected",
-				"--timeout", "60s",
-			)
-			_, err := utils.Run(cmd)
-			g.Expect(err).NotTo(HaveOccurred())
-		}, vmReadyTimeout, 15*time.Second).Should(Succeed())
-
-		By("locating the virt-launcher pod for QGA verification")
-		Eventually(func(g Gomega) {
-			cmd := exec.Command("kubectl", "-n", kvNamespace, "get", "pod",
-				"-l", fmt.Sprintf("vm.kubevirt.io/name=%s", vmName),
-				"-o", "jsonpath={.items[0].metadata.name}",
-			)
-			out, err := utils.Run(cmd)
-			g.Expect(err).NotTo(HaveOccurred())
-			launcherPod = strings.TrimSpace(out)
-			g.Expect(launcherPod).NotTo(BeEmpty(), "virt-launcher pod not found yet")
-		}).Should(Succeed())
+		launcherPod = bootRouterVM(kvNamespace, vmName, routerContainerDisk)
 	})
 
 	AfterAll(func() {
@@ -286,6 +237,86 @@ var _ = Describe("KubeVirt provider data path", Ordered, Label("kubevirt-e2e"), 
 	})
 })
 
+// deployOperator installs the CRDs and deploys the controller-manager, then
+// waits for its Deployment to report condition=Available. Shared by every
+// k3s-only e2e suite's BeforeAll (kubevirt-e2e and rollout-e2e): each suite is
+// designed to run standalone (the k3s CI job focuses one ginkgo label at a
+// time), so each deploys the operator itself rather than depending on the
+// Kind-oriented "Manager" suite's ordering. make install / make deploy are
+// idempotent `kubectl apply`s (make deploy also creates the operator
+// namespace), so calling this from more than one suite in the same run is
+// safe.
+func deployOperator() {
+	By("installing CRDs")
+	_, err := utils.Run(exec.Command("make", "install"))
+	Expect(err).NotTo(HaveOccurred(), "Failed to install CRDs")
+
+	By("deploying the controller-manager")
+	_, err = utils.Run(exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectImage)))
+	Expect(err).NotTo(HaveOccurred(), "Failed to deploy the controller-manager")
+
+	By("waiting for the controller-manager deployment to be Available")
+	Eventually(func(g Gomega) {
+		cmd := exec.Command("kubectl", "wait",
+			"deployment.apps/vrouter-operator-controller-manager",
+			"--for", "condition=Available",
+			"--namespace", namespace,
+			"--timeout", "60s",
+		)
+		_, err := utils.Run(cmd)
+		g.Expect(err).NotTo(HaveOccurred())
+	}, 5*time.Minute, 10*time.Second).Should(Succeed())
+}
+
+// bootRouterVM creates a VirtualMachine named vmName (booting image) in ns,
+// waits for it to reach condition=Ready and its VMI to reach
+// condition=AgentConnected, then locates and returns its virt-launcher pod
+// name for QGA use. Shared by kubevirt-e2e's single-VM BeforeAll,
+// rollout-e2e's two-VM BeforeAll, and rollout-e2e's delete+recreate
+// reboot-re-dispatch spec, so the (generous, hardware-KVM-sized) boot budget
+// and polling behavior can never drift between callers.
+func bootRouterVM(ns, vmName, image string) string { //nolint:unparam // ns kept explicit for reuse
+	By(fmt.Sprintf("creating the guest virtual-router VirtualMachine %s", vmName))
+	Expect(applyManifest(virtualMachineManifest(vmName, ns, image))).
+		To(Succeed(), fmt.Sprintf("Failed to create the VirtualMachine %s", vmName))
+
+	By(fmt.Sprintf("waiting for %s to become Ready (VMI created + running)", vmName))
+	Eventually(func(g Gomega) {
+		cmd := exec.Command("kubectl", "-n", ns, "wait",
+			fmt.Sprintf("vm/%s", vmName),
+			"--for", "condition=Ready",
+			"--timeout", "60s",
+		)
+		_, err := utils.Run(cmd)
+		g.Expect(err).NotTo(HaveOccurred())
+	}, vmReadyTimeout, 15*time.Second).Should(Succeed())
+
+	By(fmt.Sprintf("waiting for the qemu-guest-agent to connect on %s (VMI AgentConnected)", vmName))
+	Eventually(func(g Gomega) {
+		cmd := exec.Command("kubectl", "-n", ns, "wait",
+			fmt.Sprintf("vmi/%s", vmName),
+			"--for", "condition=AgentConnected",
+			"--timeout", "60s",
+		)
+		_, err := utils.Run(cmd)
+		g.Expect(err).NotTo(HaveOccurred())
+	}, vmReadyTimeout, 15*time.Second).Should(Succeed())
+
+	var launcherPod string
+	By(fmt.Sprintf("locating the virt-launcher pod for %s (QGA verification)", vmName))
+	Eventually(func(g Gomega) {
+		cmd := exec.Command("kubectl", "-n", ns, "get", "pod",
+			"-l", fmt.Sprintf("vm.kubevirt.io/name=%s", vmName),
+			"-o", "jsonpath={.items[0].metadata.name}",
+		)
+		out, err := utils.Run(cmd)
+		g.Expect(err).NotTo(HaveOccurred())
+		launcherPod = strings.TrimSpace(out)
+		g.Expect(launcherPod).NotTo(BeEmpty(), "virt-launcher pod not found yet")
+	}).Should(Succeed())
+	return launcherPod
+}
+
 // virtualMachineManifest renders a KubeVirt VirtualMachine (runStrategy=Always)
 // booting the given containerDisk image as the guest virtual router. A real VM
 // (not a bare VMI) so it exercises the same object the operator targets by name.
@@ -310,7 +341,7 @@ spec:
           type: q35
         resources:
           requests:
-            memory: 2Gi
+            memory: 1Gi
         devices:
           disks:
             - name: containerdisk
@@ -339,6 +370,84 @@ spec:
       name: %[3]s
       namespace: %[2]s
 `, name, ns, vmName)
+}
+
+// vrouterTargetWithParamsManifest renders a VRouterTarget like
+// vrouterTargetManifest, plus spec.params.hostname — the highest-priority
+// params layer (SPEC §7.1/§4.2), for use with a VRouterBinding whose template
+// renders `{{ .hostname }}` (vrouterTemplateManifest below). Kept as a
+// separate helper rather than changing vrouterTargetManifest's signature, so
+// existing kubevirt-e2e callers are unaffected.
+//
+//nolint:unparam // ns mirrors vrouterTargetManifest's signature
+func vrouterTargetWithParamsManifest(name, ns, vmName, hostname string) string {
+	return fmt.Sprintf(`apiVersion: vrouter.kojuro.date/v1
+kind: VRouterTarget
+metadata:
+  name: %[1]s
+  namespace: %[2]s
+spec:
+  provider:
+    type: kubevirt
+    kubevirt:
+      name: %[3]s
+      namespace: %[2]s
+  params:
+    hostname: "%[4]s"
+`, name, ns, vmName, hostname)
+}
+
+// vrouterTemplateManifest renders a VRouterTemplate whose commands render a
+// system host-name from a `hostname` param — the binding-driven counterpart
+// to vrouterConfigManifest's direct `commands`, used by the rollout-e2e specs
+// (test/e2e/rollout_e2e_test.go) together with vrouterTargetWithParamsManifest
+// and vrouterBindingManifest.
+func vrouterTemplateManifest(name, ns string) string {
+	return fmt.Sprintf(`apiVersion: vrouter.kojuro.date/v1
+kind: VRouterTemplate
+metadata:
+  name: %[1]s
+  namespace: %[2]s
+spec:
+  commands: |
+    set system host-name '{{ .hostname }}'
+`, name, ns)
+}
+
+// vrouterBindingManifest renders a VRouterBinding referencing templateName
+// (spec.templateRef) and targetNames in order (spec.targetRefs). rollout, if
+// non-empty, is a pre-indented YAML fragment starting with "  rollout:\n"
+// that is inserted verbatim after targetRefs — letting callers express any of
+// the three rollout modes (SPEC §7.1) without this helper needing mode-
+// specific parameters. An empty rollout omits spec.rollout entirely, i.e.
+// RolloutModeDisabled (the zero value). See rolloutWaitForAppliedFragment and
+// rolloutFixedIntervalFragment for the two thin wrappers rollout-e2e uses.
+func vrouterBindingManifest(name, ns, templateName string, targetNames []string, rollout string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "apiVersion: vrouter.kojuro.date/v1\n")
+	fmt.Fprintf(&b, "kind: VRouterBinding\n")
+	fmt.Fprintf(&b, "metadata:\n  name: %s\n  namespace: %s\n", name, ns)
+	fmt.Fprintf(&b, "spec:\n")
+	fmt.Fprintf(&b, "  templateRef:\n    name: %s\n", templateName)
+	fmt.Fprintf(&b, "  targetRefs:\n")
+	for _, t := range targetNames {
+		fmt.Fprintf(&b, "    - name: %s\n", t)
+	}
+	b.WriteString(rollout)
+	return b.String()
+}
+
+// rolloutWaitForAppliedFragment renders the spec.rollout YAML fragment for
+// mode: WaitForApplied (SPEC §7.1), for use with vrouterBindingManifest.
+func rolloutWaitForAppliedFragment(pollInterval, waitAfterApplied string) string {
+	return fmt.Sprintf("  rollout:\n    mode: WaitForApplied\n    pollInterval: %s\n    waitAfterApplied: %s\n",
+		pollInterval, waitAfterApplied)
+}
+
+// rolloutFixedIntervalFragment renders the spec.rollout YAML fragment for
+// mode: FixedInterval (SPEC §7.1), for use with vrouterBindingManifest.
+func rolloutFixedIntervalFragment(waitInterval string) string {
+	return fmt.Sprintf("  rollout:\n    mode: FixedInterval\n    waitInterval: %s\n", waitInterval)
 }
 
 // vrouterConfigManifest renders a VRouterConfig that sets a deterministic system
@@ -411,6 +520,34 @@ func getJSONPath(g Gomega, configName, jsonpath string) string {
 	return strings.TrimSpace(out)
 }
 
+// getJSONPathTolerant behaves like getJSONPath but returns "" instead of
+// failing the enclosing Eventually/Consistently block when the named
+// VRouterConfig does not exist (yet, or ever) — used by rollout-e2e's
+// Consistently windows that sample a downstream target's generated config
+// before/while asserting the rollout walk has not written it (SPEC §7.1's
+// "at most one target's VRouterConfig is being written" invariant).
+// --ignore-not-found makes kubectl exit 0 with empty output for a missing
+// object instead of erroring, so a genuine kubectl failure (bad flag,
+// unreachable apiserver) still fails the assertion via g.Expect(err).
+func getJSONPathTolerant(g Gomega, configName, jsonpath string) string {
+	cmd := exec.Command("kubectl", "-n", "default", "get", "vrouterconfig", configName,
+		"--ignore-not-found", "-o", fmt.Sprintf("jsonpath=%s", jsonpath))
+	out, err := utils.Run(cmd)
+	g.Expect(err).NotTo(HaveOccurred())
+	return strings.TrimSpace(out)
+}
+
+// getBindingField reads a jsonpath expression off the named VRouterBinding,
+// failing the enclosing Eventually/Consistently block (via the supplied
+// Gomega) on error. Sibling of getJSONPath, which reads VRouterConfigs.
+func getBindingField(g Gomega, name, jsonpath string) string {
+	cmd := exec.Command("kubectl", "-n", "default", "get", "vrouterbinding", name,
+		"-o", fmt.Sprintf("jsonpath=%s", jsonpath))
+	out, err := utils.Run(cmd)
+	g.Expect(err).NotTo(HaveOccurred())
+	return strings.TrimSpace(out)
+}
+
 // guestExecCommand is a qemu-guest-agent guest-exec request.
 type guestExecCommand struct {
 	Execute   string             `json:"execute"`
@@ -456,7 +593,7 @@ func qgaGuestExec(ns, launcher, domain, path string, args ...string) (string, er
 		return "", fmt.Errorf("no pid in guest-exec response: %s", resp)
 	}
 
-	for i := 0; i < 120; i++ {
+	for range 120 {
 		statusPayload := fmt.Sprintf(`{"execute":"guest-exec-status","arguments":{"pid":%d}}`, pidResp.Return.Pid)
 		statusResp, err := virshQGA(ns, launcher, domain, statusPayload)
 		if err != nil {

--- a/test/e2e/rollout_e2e_test.go
+++ b/test/e2e/rollout_e2e_test.go
@@ -1,0 +1,526 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/tjjh89017/vrouter-operator/test/utils"
+)
+
+// VRouterBinding serial rollout (spec.rollout / status.rollout, PR #40) e2e,
+// exercising the BindingController rollout walk against two real KubeVirt
+// guest VMs on a live k3s+KubeVirt cluster. PR #40 shipped this feature with
+// UNIT tests only (internal/controller/vrouterbinding_controller.go and its
+// _test.go); this suite is the missing real-data-path coverage, sibling to
+// kubevirt_e2e_test.go's single-VM provider suite.
+//
+// Two VMs (vm-a, vm-b) are booted once in BeforeAll and shared read-mostly
+// across the four specs below; each spec creates and DeferCleanup-removes its
+// own VRouterTemplate/VRouterTarget(s)/VRouterBinding/generated VRouterConfigs
+// so the specs never leak state into each other, while paying the ~10m VM
+// boot cost only once for the whole suite (Ordered, like kubevirt_e2e_test.go).
+//
+// Guard: skipped unless E2E_CLUSTER=k3s, same rationale as kubevirt_e2e_test.go
+// — this needs a real KubeVirt + KVM node, never the default Kind suite.
+var _ = Describe("VRouterBinding serial rollout", Ordered, Label("rollout-e2e"), func() {
+	const (
+		// Both VMs and every generated CR for this suite live in the default
+		// namespace — same rationale as kubevirt_e2e_test.go's kvNamespace:
+		// the KubeVirt provider resolves kubevirt.namespace to the
+		// VRouterTarget's own namespace when omitted, and the validating
+		// webhook requires same-namespace targetRefs.
+		kvNamespace = "default"
+		vmNameA     = "rollout-e2e-vm-a"
+		vmNameB     = "rollout-e2e-vm-b"
+
+		// Spec 3: WaitForApplied serial happy path.
+		happyTemplateName = "rollout-e2e-happy-template"
+		happyTargetAName  = "rollout-e2e-happy-target-a"
+		happyTargetBName  = "rollout-e2e-happy-target-b"
+		happyBindingName  = "rollout-e2e-happy-binding"
+		happyHostnameA    = "rollouta"
+		happyHostnameB    = "rolloutb"
+
+		// Spec 4: WaitForApplied halt + resume. The template sets eth0's
+		// address (not hostname) from a param, mirroring
+		// vrouterFailingConfigManifest's proven set-time-failure pattern
+		// (kubevirt_e2e_test.go) rather than reusing the hostname template, so
+		// this spec never touches the hostname the other specs assert on.
+		haltTemplateName = "rollout-e2e-halt-template"
+		haltTargetAName  = "rollout-e2e-halt-target-a"
+		haltTargetBName  = "rollout-e2e-halt-target-b"
+		haltBindingName  = "rollout-e2e-halt-binding"
+		// haltInvalidAddr trips the same "set-time validation failure that
+		// still lets commit exit 0" behavior vrouterFailingConfigManifest
+		// documents and that CI has verified empirically for this exact guest
+		// image (kubevirt_e2e_test.go). UNCERTAIN: this test does not attempt
+		// a different invalid value (e.g. a malformed host-name); 'not-an-ip'
+		// is reused here specifically because it is the one value already
+		// proven, in this repo's own CI, to trip the router's "Set failed"
+		// marker without aborting the script.
+		haltInvalidAddr = "not-an-ip"
+		haltValidAddr   = "192.0.2.10/24"
+
+		// Spec 5: FixedInterval stagger.
+		fixedTemplateName = "rollout-e2e-fixed-template"
+		fixedTargetAName  = "rollout-e2e-fixed-target-a"
+		fixedTargetBName  = "rollout-e2e-fixed-target-b"
+		fixedBindingName  = "rollout-e2e-fixed-binding"
+		fixedHostnameA    = "fixeda"
+		fixedHostnameB    = "fixedb"
+		// fixedWaitInterval is spec 5's spec.rollout.waitInterval.
+		// fixedIntervalTolerance is how far short of fixedWaitInterval the
+		// observed frontier-advance delta is allowed to fall and still pass.
+		// UNCERTAIN: this tolerance is a guess — it has not been validated
+		// against an actual k3s+KubeVirt CI timing distribution, only reasoned
+		// about from the reconcile/requeue latencies documented in SPEC §7.1.
+		// If CI shows flakes here, widen it rather than the wait interval.
+		fixedWaitInterval      = 60 * time.Second
+		fixedIntervalTolerance = 5 * time.Second
+
+		// Spec 6: VM delete+recreate self-heal — a direct (non-binding)
+		// VRouterConfig against vm-a. See the comment on that It for why a
+		// fresh KubeVirt boot re-applies via the CheckReady-not-ready reset
+		// (not SPEC §7.2's reboot-forced path, which is Proxmox-only).
+		rebootTargetName = "rollout-e2e-reboot-target"
+		rebootConfigName = "rollout-e2e-reboot-config"
+		rebootHostname   = "rebootself"
+	)
+
+	var (
+		// routerContainerDisk is the containerDisk image booted as both guest
+		// virtual routers — see kubevirt_e2e_test.go's identically-named var.
+		routerContainerDisk string
+		// launcherPodA/B are the virt-launcher pods hosting vm-a/vm-b's VMIs;
+		// launcherPodA is reassigned by the reboot-re-dispatch spec once vm-a
+		// is recreated (a fresh VM gets a fresh virt-launcher pod).
+		launcherPodA, launcherPodB string
+		// qgaDomainA/B are the libvirt domain names virsh addresses:
+		// "<ns>_<vm>" — stable across vm-a's delete+recreate since the VM name
+		// is reused.
+		qgaDomainA, qgaDomainB string
+	)
+
+	BeforeAll(func() {
+		if e2eCluster != "k3s" {
+			Skip("rollout-e2e requires E2E_CLUSTER=k3s (real KubeVirt + KVM); skipping on the default Kind suite")
+		}
+
+		routerContainerDisk = os.Getenv("E2E_ROUTER_CONTAINERDISK")
+		if routerContainerDisk == "" {
+			routerContainerDisk = "dozenos-e2e:latest"
+		}
+		qgaDomainA = fmt.Sprintf("%s_%s", kvNamespace, vmNameA)
+		qgaDomainB = fmt.Sprintf("%s_%s", kvNamespace, vmNameB)
+
+		// This suite is designed to run standalone (the k3s CI job focuses
+		// "kubevirt-e2e || rollout-e2e" as a whole, but nothing here depends on
+		// spec execution order across files), so it deploys the operator
+		// itself, exactly like kubevirt_e2e_test.go's BeforeAll. make install /
+		// make deploy are idempotent kubectl applies, so this is harmless even
+		// if the kubevirt-e2e spec already deployed the operator in the same
+		// job run.
+		deployOperator()
+
+		launcherPodA = bootRouterVM(kvNamespace, vmNameA, routerContainerDisk)
+		launcherPodB = bootRouterVM(kvNamespace, vmNameB, routerContainerDisk)
+	})
+
+	AfterAll(func() {
+		if e2eCluster != "k3s" {
+			return
+		}
+		By("sweeping up any rollout-e2e bindings/templates/targets/configs left behind")
+		// Primary cleanup happens per-spec via DeferCleanup below; this is a
+		// belt-and-suspenders sweep so a spec that panics before registering
+		// its DeferCleanup can't leak CRs past the suite.
+		deleteBindingResources(kvNamespace, happyBindingName, happyTemplateName,
+			[]string{happyTargetAName, happyTargetBName})
+		deleteBindingResources(kvNamespace, haltBindingName, haltTemplateName,
+			[]string{haltTargetAName, haltTargetBName})
+		deleteBindingResources(kvNamespace, fixedBindingName, fixedTemplateName,
+			[]string{fixedTargetAName, fixedTargetBName})
+		_, _ = utils.Run(exec.Command(
+			"kubectl", "-n", kvNamespace, "delete", "vrouterconfig", rebootConfigName, "--ignore-not-found"))
+		_, _ = utils.Run(exec.Command(
+			"kubectl", "-n", kvNamespace, "delete", "vroutertarget", rebootTargetName, "--ignore-not-found"))
+
+		By("deleting vm-a and vm-b")
+		_, _ = utils.Run(exec.Command("kubectl", "-n", kvNamespace, "delete", "vm", vmNameA, "--ignore-not-found"))
+		_, _ = utils.Run(exec.Command("kubectl", "-n", kvNamespace, "delete", "vm", vmNameB, "--ignore-not-found"))
+	})
+
+	// Item 3: WaitForApplied serial happy path.
+	It("rolls out serially under mode: WaitForApplied and converges with both hostnames applied", func() {
+		cfgA := fmt.Sprintf("%s.%s", happyBindingName, happyTargetAName)
+		cfgB := fmt.Sprintf("%s.%s", happyBindingName, happyTargetBName)
+
+		DeferCleanup(func() {
+			deleteBindingResources(kvNamespace, happyBindingName, happyTemplateName,
+				[]string{happyTargetAName, happyTargetBName})
+		})
+
+		By("creating the template, two targets (hostA/hostB), and a WaitForApplied binding over both")
+		Expect(applyManifest(vrouterTemplateManifest(happyTemplateName, kvNamespace))).
+			To(Succeed(), "Failed to create the VRouterTemplate")
+		Expect(applyManifest(vrouterTargetWithParamsManifest(happyTargetAName, kvNamespace, vmNameA, happyHostnameA))).
+			To(Succeed(), "Failed to create target-a")
+		Expect(applyManifest(vrouterTargetWithParamsManifest(happyTargetBName, kvNamespace, vmNameB, happyHostnameB))).
+			To(Succeed(), "Failed to create target-b")
+		Expect(applyManifest(vrouterBindingManifest(happyBindingName, kvNamespace, happyTemplateName,
+			[]string{happyTargetAName, happyTargetBName},
+			rolloutWaitForAppliedFragment("10s", "0s")))).
+			To(Succeed(), "Failed to create the binding")
+
+		// Single Consistently window proving three invariants at once, sampled
+		// every 2s across the whole rollout: (a) SPEC §7.1's "at most one
+		// target's VRouterConfig is being written" — approximated here as "at
+		// most one generated config is Applying" since Applying is the
+		// observable window a write is in flight; (b) the frontier never
+		// advances to target-b while target-a is not yet Applied=True; and (c)
+		// along the way, the binding did pass through Ready=False/
+		// RolloutInProgress "1/2 targets updated" (captured into
+		// sawProgressMessage) rather than jumping straight to done.
+		By("watching the rollout: at most one config Applying at once, frontier never outruns target-a's Applied status")
+		var sawProgressMessage bool
+		Consistently(func(g Gomega) {
+			phaseA := getJSONPathTolerant(g, cfgA, "{.status.phase}")
+			phaseB := getJSONPathTolerant(g, cfgB, "{.status.phase}")
+			applyingCount := 0
+			if phaseA == "Applying" {
+				applyingCount++
+			}
+			if phaseB == "Applying" {
+				applyingCount++
+			}
+			g.Expect(applyingCount).To(BeNumerically("<=", 1),
+				"more than one generated config Applying at once: phaseA=%q phaseB=%q", phaseA, phaseB)
+
+			frontier := getBindingField(g, happyBindingName, "{.status.rollout.lastUpdatedTarget}")
+			if frontier == happyTargetBName {
+				appliedA := getJSONPath(g, cfgA, `{.status.conditions[?(@.type=="Applied")].status}`)
+				g.Expect(appliedA).To(Equal("True"),
+					"rollout frontier advanced to target-b while target-a's config is not yet Applied=True")
+			}
+
+			readyMsg := getBindingField(g, happyBindingName, `{.status.conditions[?(@.type=="Ready")].message}`)
+			if readyMsg == "1/2 targets updated" {
+				sawProgressMessage = true
+			}
+		}, 6*time.Minute, 2*time.Second).Should(Succeed())
+		Expect(sawProgressMessage).To(BeTrue(),
+			`never observed the binding Ready message "1/2 targets updated" during the rollout`)
+
+		By("verifying binding Ready settles to True/ReconcileSucceeded once both configs are applied")
+		Eventually(func(g Gomega) {
+			status := getBindingField(g, happyBindingName, `{.status.conditions[?(@.type=="Ready")].status}`)
+			reason := getBindingField(g, happyBindingName, `{.status.conditions[?(@.type=="Ready")].reason}`)
+			message := getBindingField(g, happyBindingName, `{.status.conditions[?(@.type=="Ready")].message}`)
+			g.Expect(status).To(Equal("True"), "Ready reason=%q message=%q", reason, message)
+			g.Expect(reason).To(Equal("ReconcileSucceeded"))
+			g.Expect(message).To(Equal("All 2 VRouterConfigs applied."))
+		}, applyTimeout, applyPoll).Should(Succeed())
+
+		By("verifying both guests reflect their applied hostnames via QGA")
+		expectGuestHostname(kvNamespace, launcherPodA, qgaDomainA, happyHostnameA)
+		expectGuestHostname(kvNamespace, launcherPodB, qgaDomainB, happyHostnameB)
+	})
+
+	// Item 4: WaitForApplied halt + resume.
+	It("halts a WaitForApplied rollout on a Failed config and resumes once it is fixed", func() {
+		cfgA := fmt.Sprintf("%s.%s", haltBindingName, haltTargetAName)
+		cfgB := fmt.Sprintf("%s.%s", haltBindingName, haltTargetBName)
+
+		DeferCleanup(func() {
+			deleteBindingResources(kvNamespace, haltBindingName, haltTemplateName,
+				[]string{haltTargetAName, haltTargetBName})
+		})
+
+		By("creating a template that sets eth0's address from a param, target-a with an INVALID address, target-b valid")
+		Expect(applyManifest(addressTemplateManifest(haltTemplateName, kvNamespace))).
+			To(Succeed(), "Failed to create the VRouterTemplate")
+		Expect(applyManifest(targetWithAddrParamManifest(haltTargetAName, kvNamespace, vmNameA, haltInvalidAddr))).
+			To(Succeed(), "Failed to create target-a")
+		Expect(applyManifest(targetWithAddrParamManifest(haltTargetBName, kvNamespace, vmNameB, haltValidAddr))).
+			To(Succeed(), "Failed to create target-b")
+
+		By("creating the binding (rollout WaitForApplied, targetRefs [target-a, target-b])")
+		Expect(applyManifest(vrouterBindingManifest(haltBindingName, kvNamespace, haltTemplateName,
+			[]string{haltTargetAName, haltTargetBName},
+			rolloutWaitForAppliedFragment("10s", "0s")))).
+			To(Succeed(), "Failed to create the binding")
+
+		By("waiting for the binding to halt: Ready=False/RolloutHalted naming target-a's generated config")
+		Eventually(func(g Gomega) {
+			status := getBindingField(g, haltBindingName, `{.status.conditions[?(@.type=="Ready")].status}`)
+			reason := getBindingField(g, haltBindingName, `{.status.conditions[?(@.type=="Ready")].reason}`)
+			message := getBindingField(g, haltBindingName, `{.status.conditions[?(@.type=="Ready")].message}`)
+			g.Expect(status).To(Equal("False"), "Ready reason=%q message=%q", reason, message)
+			g.Expect(reason).To(Equal("RolloutHalted"))
+			g.Expect(message).To(ContainSubstring(cfgA))
+		}, failTimeout, applyPoll).Should(Succeed())
+
+		By("verifying target-b's generated config is never written while the rollout is halted")
+		Consistently(func(g Gomega) {
+			name := getJSONPathTolerant(g, cfgB, "{.metadata.name}")
+			g.Expect(name).To(BeEmpty(), "downstream VRouterConfig %q was written while the rollout is halted", cfgB)
+		}, 45*time.Second, 5*time.Second).Should(Succeed())
+
+		By("resuming: patching target-a's addr param to a valid value")
+		Expect(applyManifest(targetWithAddrParamManifest(haltTargetAName, kvNamespace, vmNameA, haltValidAddr))).
+			To(Succeed(), "Failed to patch target-a")
+
+		By("verifying the rollout resumes: both generated configs reach Applied")
+		Eventually(func(g Gomega) {
+			appliedA := getJSONPath(g, cfgA, `{.status.conditions[?(@.type=="Applied")].status}`)
+			appliedB := getJSONPath(g, cfgB, `{.status.conditions[?(@.type=="Applied")].status}`)
+			g.Expect(appliedA).To(Equal("True"))
+			g.Expect(appliedB).To(Equal("True"))
+		}, applyTimeout, applyPoll).Should(Succeed())
+
+		By("verifying the binding settles Ready=True/ReconcileSucceeded")
+		Eventually(func(g Gomega) {
+			status := getBindingField(g, haltBindingName, `{.status.conditions[?(@.type=="Ready")].status}`)
+			reason := getBindingField(g, haltBindingName, `{.status.conditions[?(@.type=="Ready")].reason}`)
+			g.Expect(status).To(Equal("True"), "Ready reason=%q", reason)
+			g.Expect(reason).To(Equal("ReconcileSucceeded"))
+		}, applyTimeout, applyPoll).Should(Succeed())
+	})
+
+	// Item 5: FixedInterval stagger.
+	It("staggers writes by waitInterval under mode: FixedInterval", func() {
+		DeferCleanup(func() {
+			deleteBindingResources(kvNamespace, fixedBindingName, fixedTemplateName,
+				[]string{fixedTargetAName, fixedTargetBName})
+		})
+
+		By(fmt.Sprintf("creating template + targets + FixedInterval binding (waitInterval=%s)", fixedWaitInterval))
+		Expect(applyManifest(vrouterTemplateManifest(fixedTemplateName, kvNamespace))).
+			To(Succeed(), "Failed to create the VRouterTemplate")
+		Expect(applyManifest(vrouterTargetWithParamsManifest(fixedTargetAName, kvNamespace, vmNameA, fixedHostnameA))).
+			To(Succeed(), "Failed to create target-a")
+		Expect(applyManifest(vrouterTargetWithParamsManifest(fixedTargetBName, kvNamespace, vmNameB, fixedHostnameB))).
+			To(Succeed(), "Failed to create target-b")
+		Expect(applyManifest(vrouterBindingManifest(fixedBindingName, kvNamespace, fixedTemplateName,
+			[]string{fixedTargetAName, fixedTargetBName},
+			rolloutFixedIntervalFragment(fixedWaitInterval.String())))).
+			To(Succeed(), "Failed to create the binding")
+
+		By("waiting for the rollout frontier to reach target-a")
+		var timeA string
+		Eventually(func(g Gomega) {
+			frontier := getBindingField(g, fixedBindingName, "{.status.rollout.lastUpdatedTarget}")
+			g.Expect(frontier).To(Equal(fixedTargetAName))
+			timeA = getBindingField(g, fixedBindingName, "{.status.rollout.lastUpdateTime}")
+			g.Expect(timeA).NotTo(BeEmpty())
+		}, applyTimeout, applyPoll).Should(Succeed())
+
+		By("waiting for the rollout frontier to advance to target-b after waitInterval")
+		var timeB string
+		Eventually(func(g Gomega) {
+			frontier := getBindingField(g, fixedBindingName, "{.status.rollout.lastUpdatedTarget}")
+			g.Expect(frontier).To(Equal(fixedTargetBName))
+			timeB = getBindingField(g, fixedBindingName, "{.status.rollout.lastUpdateTime}")
+			g.Expect(timeB).NotTo(BeEmpty())
+		}, applyTimeout, applyPoll).Should(Succeed())
+
+		By("asserting the stagger honored waitInterval, allowing a small scheduling tolerance")
+		tA, err := time.Parse(time.RFC3339, timeA)
+		Expect(err).NotTo(HaveOccurred(), "failed to parse status.rollout.lastUpdateTime for target-a: %q", timeA)
+		tB, err := time.Parse(time.RFC3339, timeB)
+		Expect(err).NotTo(HaveOccurred(), "failed to parse status.rollout.lastUpdateTime for target-b: %q", timeB)
+		delta := tB.Sub(tA)
+		Expect(delta).To(BeNumerically(">=", fixedWaitInterval-fixedIntervalTolerance),
+			"frontier advanced from target-a to target-b after only %s, less than waitInterval %s minus tolerance %s",
+			delta, fixedWaitInterval, fixedIntervalTolerance)
+
+		By("verifying both hostnames eventually land in-guest")
+		expectGuestHostname(kvNamespace, launcherPodA, qgaDomainA, fixedHostnameA)
+		expectGuestHostname(kvNamespace, launcherPodB, qgaDomainB, fixedHostnameB)
+	})
+
+	// Item 6: VM delete+recreate self-heal — after a KubeVirt guest is torn
+	// down and rebooted from its stateless containerDisk, the operator
+	// re-applies the previously-Applied config to the fresh guest.
+	//
+	// WHY this re-applies WITHOUT KubeVirt reboot detection (verified against
+	// the controller source, not assumed): SPEC §7.2's reboot-forced re-apply
+	// is driven by VRouterTarget.Status.LastRebootTime, which only
+	// ProxmoxClusterController ever writes — so shouldForceReapplyForReboot is
+	// always false for a KubeVirt target
+	// (internal/controller/vrouterconfig_controller.go:204). Re-apply instead
+	// comes from the CheckReady reset path:
+	//  1. Recreating the VM fires a VMI event that re-enqueues this config (the
+	//     VirtualMachineInstance watch, vrouterconfig_controller.go:517).
+	//  2. KubeVirt IsVMRunning returns true as soon as the VMI is in a running
+	//     phase — well BEFORE the guest OS/QGA is up (kubevirt/provider.go's
+	//     IsVMRunning only excludes Succeeded/Failed) — so onChange does not
+	//     short-circuit; it proceeds to CheckReady.
+	//  3. CheckReady transiently FAILS on the still-booting guest (QGA not
+	//     responding, or the router unit not yet "exited"), and
+	//     handleRouterNotReady resets a previously-Applied config to
+	//     phase=Pending / Applied=False,RouterNotReady
+	//     (vrouterconfig_controller.go:257), re-opening the generation gate in
+	//     dispatchOrPoll so the next ready reconcile re-dispatches the apply.
+	// The containerDisk is stateless, so the recreated guest boots WITHOUT the
+	// applied host-name; observing it reappear is therefore proof the operator
+	// re-applied it, not residue from before. (Delete+recreate is the spec that
+	// exercises this real reboot-recovery path end to end.)
+	It("re-applies a previously-Applied config to a freshly recreated guest VM", func() {
+		DeferCleanup(func() {
+			_, _ = utils.Run(exec.Command(
+				"kubectl", "-n", kvNamespace, "delete", "vrouterconfig", rebootConfigName, "--ignore-not-found"))
+			_, _ = utils.Run(exec.Command(
+				"kubectl", "-n", kvNamespace, "delete", "vroutertarget", rebootTargetName, "--ignore-not-found"))
+		})
+
+		By("creating a direct VRouterTarget + VRouterConfig against vm-a")
+		Expect(applyManifest(vrouterTargetManifest(rebootTargetName, kvNamespace, vmNameA))).
+			To(Succeed(), "Failed to create the VRouterTarget")
+		Expect(applyManifest(vrouterConfigManifest(rebootConfigName, kvNamespace, rebootTargetName, rebootHostname))).
+			To(Succeed(), "Failed to create the VRouterConfig")
+
+		By("waiting for the config to reach Applied and recording the Applied transition time")
+		var appliedTransitionBefore time.Time
+		Eventually(func(g Gomega) {
+			appliedStatus := getJSONPath(g, rebootConfigName, `{.status.conditions[?(@.type=="Applied")].status}`)
+			g.Expect(appliedStatus).To(Equal("True"))
+			ts := getJSONPath(g, rebootConfigName, `{.status.conditions[?(@.type=="Applied")].lastTransitionTime}`)
+			g.Expect(ts).NotTo(BeEmpty())
+			parsed, err := time.Parse(time.RFC3339, ts)
+			g.Expect(err).NotTo(HaveOccurred())
+			appliedTransitionBefore = parsed
+		}, applyTimeout, applyPoll).Should(Succeed())
+		By("verifying the host-name landed in-guest before the VM is torn down")
+		expectGuestHostname(kvNamespace, launcherPodA, qgaDomainA, rebootHostname)
+
+		By("deleting vm-a and waiting for it to be fully gone")
+		_, err := utils.Run(exec.Command("kubectl", "-n", kvNamespace, "delete", "vm", vmNameA,
+			"--ignore-not-found", "--wait=true", "--timeout=120s"))
+		Expect(err).NotTo(HaveOccurred(), "Failed to delete vm-a")
+
+		By("recreating vm-a from its stateless containerDisk (fresh boot resets the host-name to the image default)")
+		launcherPodA = bootRouterVM(kvNamespace, vmNameA, routerContainerDisk)
+
+		// The re-apply is proven two ways that must agree: (a) the Applied
+		// condition re-transitions (its lastTransitionTime advances past the
+		// pre-teardown value — it can only do so by going True->False->True
+		// through the RouterNotReady reset), and (b) the host-name reappears in
+		// the fresh guest, which a stateless boot could only get from a genuine
+		// re-apply. If the guest booted fast enough that no reconcile ever caught
+		// CheckReady failing, neither would hold and this spec would (correctly)
+		// fail — surfacing that the reboot-recovery window was missed.
+		By("verifying the operator re-applies to the fresh guest: Applied re-transitions")
+		Eventually(func(g Gomega) {
+			appliedStatus := getJSONPath(g, rebootConfigName, `{.status.conditions[?(@.type=="Applied")].status}`)
+			g.Expect(appliedStatus).To(Equal("True"))
+			ts := getJSONPath(g, rebootConfigName, `{.status.conditions[?(@.type=="Applied")].lastTransitionTime}`)
+			g.Expect(ts).NotTo(BeEmpty())
+			parsed, err := time.Parse(time.RFC3339, ts)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(parsed.After(appliedTransitionBefore)).To(BeTrue(),
+				"Applied condition never re-transitioned after vm-a was recreated "+
+					"(was %s, still %s) — the config was not re-applied",
+				appliedTransitionBefore, parsed)
+		}, applyTimeout, applyPoll).Should(Succeed())
+
+		By("verifying the host-name is re-applied into the freshly booted guest")
+		expectGuestHostname(kvNamespace, launcherPodA, qgaDomainA, rebootHostname)
+	})
+})
+
+// deleteBindingResources deletes a binding-driven resource set: the
+// generated VRouterConfigs (named "<binding>.<target>" for each target in
+// targets), the binding itself, the targets, and the template. Shared by
+// every rollout-e2e spec's DeferCleanup, and by the suite's AfterAll safety
+// net, so a spec's resources never leak into the next one.
+// ns is always "default" today; kept explicit for reuse (unparam false positive).
+func deleteBindingResources(ns, binding, template string, targets []string) { //nolint:unparam
+	cfgArgs := make([]string, 0, 4+len(targets)+1)
+	cfgArgs = append(cfgArgs, "-n", ns, "delete", "vrouterconfig")
+	for _, t := range targets {
+		cfgArgs = append(cfgArgs, fmt.Sprintf("%s.%s", binding, t))
+	}
+	cfgArgs = append(cfgArgs, "--ignore-not-found")
+	_, _ = utils.Run(exec.Command("kubectl", cfgArgs...))
+
+	_, _ = utils.Run(exec.Command("kubectl", "-n", ns, "delete", "vrouterbinding", binding, "--ignore-not-found"))
+
+	targetArgs := append([]string{"-n", ns, "delete", "vroutertarget"}, targets...)
+	targetArgs = append(targetArgs, "--ignore-not-found")
+	_, _ = utils.Run(exec.Command("kubectl", targetArgs...))
+
+	_, _ = utils.Run(exec.Command("kubectl", "-n", ns, "delete", "vroutertemplate", template, "--ignore-not-found"))
+}
+
+// expectGuestHostname asserts, via a generous Eventually (never a single
+// assert against a live cluster), that the guest reachable through
+// launcher/domain reports hostname via QGA's /bin/hostname.
+//
+//nolint:unparam // ns kept explicit like qgaGuestExec's own signature
+func expectGuestHostname(ns, launcher, domain, hostname string) {
+	Eventually(func(g Gomega) {
+		out, err := qgaGuestExec(ns, launcher, domain, "/bin/hostname")
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(strings.TrimSpace(out)).To(Equal(hostname))
+	}, applyTimeout, applyPoll).Should(Succeed())
+}
+
+// addressTemplateManifest renders a VRouterTemplate that sets eth0's
+// interface address from a params.addr value. Used only by the halt+resume
+// spec to trip a set-time validation failure the same way
+// vrouterFailingConfigManifest does (kubevirt_e2e_test.go), without touching
+// system host-name — which the other rollout specs sharing these two VMs
+// assert on.
+func addressTemplateManifest(name, ns string) string {
+	return fmt.Sprintf(`apiVersion: vrouter.kojuro.date/v1
+kind: VRouterTemplate
+metadata:
+  name: %[1]s
+  namespace: %[2]s
+spec:
+  commands: |
+    set interfaces ethernet eth0 address '{{ .addr }}'
+`, name, ns)
+}
+
+// targetWithAddrParamManifest renders a VRouterTarget identifying vmName,
+// with spec.params.addr set to addr, for use with addressTemplateManifest.
+func targetWithAddrParamManifest(name, ns, vmName, addr string) string {
+	return fmt.Sprintf(`apiVersion: vrouter.kojuro.date/v1
+kind: VRouterTarget
+metadata:
+  name: %[1]s
+  namespace: %[2]s
+spec:
+  provider:
+    type: kubevirt
+    kubevirt:
+      name: %[3]s
+      namespace: %[2]s
+  params:
+    addr: "%[4]s"
+`, name, ns, vmName, addr)
+}


### PR DESCRIPTION
## Summary

The serial rollout feature (`spec.rollout` / `status.rollout` on VRouterBinding, shipped in #40) had **unit tests only**. This adds a real-data-path e2e suite (ginkgo label `rollout-e2e`) that drives it end to end against two live KubeVirt guest VMs on the k3s+KVM CI harness from #41.

## Specs

| Spec | Asserts |
|------|---------|
| WaitForApplied serial happy path | at most one generated config `Applying` at a time; `status.rollout` frontier never outruns the prior target's `Applied=True`; binding `Ready` walks `RolloutInProgress "1/2 targets updated"` → `True/"All 2 VRouterConfigs applied."`; both host-names verified in-guest via QGA |
| WaitForApplied halt + resume | a Failed generated config halts the walk (`Ready=False/RolloutHalted` naming `<binding>.<target>`); the downstream target's config is never written while halted; fixing the target's params resumes the rollout to full `Applied` |
| FixedInterval stagger | consecutive frontier `lastUpdateTime` stamps are `>= waitInterval` apart; frontier walks `targetRefs` order |
| VM delete+recreate self-heal | a recreated guest boots from its stateless disk and the operator **re-applies** the previously-Applied config — via the CheckReady-not-ready reset path (`handleRouterNotReady` resets `Applied→Pending`), not reboot detection (KubeVirt has none). Proven by the `Applied` condition re-transitioning **and** the host-name reappearing in the fresh guest |

## Harness / CI changes

- Shared `deployOperator` / `bootRouterVM` helpers + `vrouterTemplateManifest` / `vrouterBindingManifest` / `vrouterTargetWithParamsManifest` / rollout-fragment builders extracted alongside the existing `kubevirt-e2e` suite.
- Guest VM memory request lowered **2Gi → 1Gi** so two guests fit one runner.
- CI runs both labels (`GINKGO_LABEL_FILTER='kubevirt-e2e || rollout-e2e'`), job `timeout-minutes` 40 → 70, `E2E_TIMEOUT=60m` for the second suite.

## Verification

`gofmt` clean · `go vet ./test/e2e/...` clean · `go build ./...` clean · `golangci-lint run ./test/e2e/...` 0 issues · ginkgo dry-run discovers all 6 specs (2 `kubevirt-e2e` + 4 `rollout-e2e`). The suite itself is exercised by the **E2E KubeVirt** job on this PR (needs real KVM).

Refs #38